### PR TITLE
add cron job to RecurShifts, extract time and location constants to config.js

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -6,15 +6,50 @@ config.wheniwork = {
     api_key: 'TODO',
     username: 'TODO',
     password: 'TODO',
-    default_password: 'TODO',
-    new_graduate_location_id: 'TODO',
-    makeup_and_extra_shifts_location_id: 'TODO',
-    regular_shifts_location_id: 'TODO',
-    test_location_id: 'TODO',
-    test2_location_id: 'TODO', 
-    supervisors_location_id: 'TODO',
-    crisis_counselors_demo_location_id: 'TODO'
+    default_password: 'TODO'
 };
+
+config.locationID = {
+    new_graduate: 959290,
+    makeup_and_extra_shifts: 1003762,
+    regular_shifts: 1003765,
+    test: 990385,
+    test2: 1007104,
+    supervisors: 884473,
+    crisis_counselors_demo: 1004215
+}
+
+config.time_interval = {
+    // runs every 5 mins. 
+    recur_and_publish_shifts_cron_job_string: '0 */5 * * * *',
+
+    // runs every 20 mins. 
+    notify_first_shift_cron_job_string: '0 */20 * * * *',
+
+    // runs every day at 11:00 and 23:00. 
+    time_off_requests_cron_job_string: '0 0 11,23 * * *',
+
+    // Each recurrence chain is 1 year long. 
+    max_shifts_in_chain: 52,
+    
+    // Buffer added to end of chain to ensure that edge cases don't result in skipped weeks. 
+    chain_buffer_days: 1,
+
+    // Each shift is recurred for 5 years. 
+    years_to_recur_shift 5,
+
+    // In looking for newly created shifts to recur, we search 2 weeks from the present.
+    weeks_to_search_for_recurred_shifts: 2,
+
+    // While we recur shifts for much longer, they're only published (viewable to the employee) 4 weeks from present.
+    weeks_to_publish_recurred_shifts: 4,
+
+    // Used to search for requests to be auto-approved. 
+    months_to_search_for_time_off_requests: 6,
+
+    // Used to search for users in order to notify them via email.  
+    days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7
+}
 
 config.mandrill = {
     api_key: 'TODO'

--- a/config.js.default
+++ b/config.js.default
@@ -6,7 +6,14 @@ config.wheniwork = {
     api_key: 'TODO',
     username: 'TODO',
     password: 'TODO',
-    default_password: 'TODO'
+    default_password: 'TODO',
+    new_graduate_location_id: 'TODO',
+    makeup_and_extra_shifts_location_id: 'TODO',
+    regular_shifts_location_id: 'TODO',
+    test_location_id: 'TODO',
+    test2_location_id: 'TODO', 
+    supervisors_location_id: 'TODO',
+    crisis_counselors_demo_location_id: 'TODO'
 };
 
 config.mandrill = {

--- a/jobs/scheduling/NotifyFirstShift.js
+++ b/jobs/scheduling/NotifyFirstShift.js
@@ -6,10 +6,11 @@ var fs = require('fs');
 var mandrill = require('mandrill-api/mandrill');
 var mandrill_client = new mandrill.Mandrill(global.config.mandrill.api_key);
 
-var interval = 20;
 var date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-new CronJob('0 */'+interval+' * * * *', function () {
+const DAYS_TO_SEARCH_FOR_NEW_USERS_WHO_HAVE_SCHEDULED_THEIR_FIRST_SHIFT = global.config.days_to_search_for_new_users_who_have_scheduled_their_first_shift;
+
+new CronJob(global.config.time_interval.notify_first_shift_cron_job_string, function () {
     checkNewShifts();
 }, null, true);
 
@@ -25,11 +26,11 @@ function checkNewShifts() {
             var u = users.users[i];
             var created = moment(u.created_at, date_format);
 
-            if (u.notes.indexOf('first_shift_notified') < 0 && now.diff(created, 'days') < 7) {
+            if (u.notes.indexOf('first_shift_notified') < 0 && now.diff(created, 'days') < DAYS_TO_SEARCH_FOR_NEW_USERS_WHO_HAVE_SCHEDULED_THEIR_FIRST_SHIFT) {
                 var q = {
                     user_id: u.id,
                     start: moment().format(date_format),
-                    end: moment().add(7, 'days').format(date_format)
+                    end: moment().add(DAYS_TO_SEARCH_FOR_NEW_USERS_WHO_HAVE_SCHEDULED_THEIR_FIRST_SHIFT, 'days').format(date_format)
                 };
 
                 WhenIWork.get('shifts', q, function (shifts) {

--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -18,8 +18,13 @@ const CHAIN_BUFFER_DAYS = 1;
 const YEARS_TO_RECUR_SHIFT = 5;
 const WEEKS_TO_SEARCH_FOR_RECURRED_SHIFTS = 2;
 const WEEKS_TO_PUBLISH_RECURRED_SHIFTS = 4;
-// @TODO: we'll later want to filter for more than one location
-const LOCATION_ID = 990385;
+
+if (process.env.NODE_ENV == 'production') {
+    const LOCATION_ID = config.wheniwork.regular_shifts_location_id;
+}
+else {
+    const LOCATION_ID = config.wheniwork.test_location_id;
+}
 
 function recurNewlyCreatedShifts() {
     var batchPostRequestBody = [];

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -3,14 +3,16 @@ var WhenIWork = require('./base');
 var moment = require('moment');
 var fs = require('fs');
 
+const MONTHS_TO_SEARCH_FOR_TIME_OFF_REQUESTS = global.config.months_to_search_for_time_off_requests;
+
 if (process.env.NODE_ENV == 'production') {
-    const LOCATION_ID = config.wheniwork.regular_shifts_location_id;
+    const LOCATION_ID = global.config.locationID.regular_shifts;
 }
 else {
-    const LOCATION_ID = config.wheniwork.test_location_id;
+    const LOCATION_ID = global.config.locationID.test;
 }
 
-new CronJob('0 0 11,23 * * *', function () {
+new CronJob(global.config.time_interval.time_off_requests_cron_job_string, function () {
     handleTimeOffRequests();
 }, null, true);
 
@@ -19,7 +21,7 @@ handleTimeOffRequests();
 function handleTimeOffRequests() {
     //Using moment.js to format time as WIW expects
     var startDateToRetrieveRequests = moment().format('YYYY-MM-DD HH:mm:ss');
-    var endDateToRetrieveRequests = moment().add(6, 'months').format('YYYY-MM-DD HH:mm:ss');
+    var endDateToRetrieveRequests = moment().add(MONTHS_TO_SEARCH_FOR_TIME_OFF_REQUESTS, 'months').format('YYYY-MM-DD HH:mm:ss');
     var timeOffSearchParams = {
         "start": startDateToRetrieveRequests,
         "end": endDateToRetrieveRequests,
@@ -45,6 +47,7 @@ function handleTimeOffRequests() {
             };
 
             WhenIWork.get('shifts', shiftSearchParams, function(response) {
+                // Status code `2` represents approved requests. 
                 var timeOffApprovalRequest = {
                     "method": "put",
                     "url": "/2/requests/" + request.id,

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -3,8 +3,12 @@ var WhenIWork = require('./base');
 var moment = require('moment');
 var fs = require('fs');
 
-//TODO:  Below is Test Location ID, eventually we want to look at New Graduates and Regular locations
-const LOCATION_ID = 990385;
+if (process.env.NODE_ENV == 'production') {
+    const LOCATION_ID = config.wheniwork.regular_shifts_location_id;
+}
+else {
+    const LOCATION_ID = config.wheniwork.test_location_id;
+}
 
 new CronJob('0 0 11,23 * * *', function () {
     handleTimeOffRequests();

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -15,7 +15,7 @@ handleTimeOffRequests();
 function handleTimeOffRequests() {
     //Using moment.js to format time as WIW expects
     var startDateToRetrieveRequests = moment().format('YYYY-MM-DD HH:mm:ss');
-    var endDateToRetrieveRequests = moment().add(1, 'months').format('YYYY-MM-DD HH:mm:ss');
+    var endDateToRetrieveRequests = moment().add(6, 'months').format('YYYY-MM-DD HH:mm:ss');
     var timeOffSearchParams = {
         "start": startDateToRetrieveRequests,
         "end": endDateToRetrieveRequests,
@@ -27,8 +27,7 @@ function handleTimeOffRequests() {
 
         //Filter requests to pending requests only
         var newRequests = allRequests.filter(function(request) {
-            //THIS MUST BE CHANGED TO === 0 IN PROD
-            return request.status !== 2;
+            return request.status !== 0;
         });
 
         //For each pending request, look for any shifts that fall within the time off request

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -4,10 +4,10 @@ var moment    = require.main.require('moment');
 var sha1      = require.main.require('sha1');
 
 if (process.env.NODE_ENV == 'production') {
-    const LOCATION_ID = config.wheniwork.regular_shifts_location_id;
+    const LOCATION_ID = global.config.locationID.regular_shifts;
 }
 else {
-    const LOCATION_ID = config.wheniwork.test_location_id;
+    const LOCATION_ID = global.config.locationID.test;
 }
 
 var router = express.Router();

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -3,6 +3,13 @@ var WhenIWork = require.main.require('wheniwork-unofficial');
 var moment    = require.main.require('moment');
 var sha1      = require.main.require('sha1');
 
+if (process.env.NODE_ENV == 'production') {
+    const LOCATION_ID = config.wheniwork.regular_shifts_location_id;
+}
+else {
+    const LOCATION_ID = config.wheniwork.test_location_id;
+}
+
 var router = express.Router();
 
 var api = new WhenIWork(global.config.wheniwork.api_key, global.config.wheniwork.username, global.config.wheniwork.password);
@@ -39,7 +46,7 @@ router.get('/cancel-shift', function(req, res) {
                     start: moment().format('YYYY-MM-DD 00:00:00'),
                     end: moment([2050]).format('YYYY-MM-DD HH:mm:ss'),
                     unpublished: true,
-                    location_id: '959290,959293,959296,959299,959302'
+                    location_id: LOCATION_ID
                 };
 
                 api.get('shifts', q, function (shifts) {
@@ -85,7 +92,7 @@ function checkUser(email, first, last, callback) {
             first_name: first,
             last_name: last,
             activated: true,
-            locations: [959290],
+            locations: [LOCATION_ID],
             password: global.config.wheniwork.default_password
         };
 


### PR DESCRIPTION
#### What's this PR do?
Adds a cron job to RecurShifts, extract time and location constants to config.js. (Note that we've committed `time_interval` and `locationID` constants to the `config.js.default` config template file, since it's not insecure to publish these. 

Has not yet been tested. 

#### How should this be manually tested?
Since all cron jobs run first on start, start the app to test if shift recurrence, first shift notification, and time off request auto-approval works. 

#### Questions:
Is assigning `const CONSTANT_NAME = global.config.locationID.variable_name` at the top of files superfluous? Should we just use references to `global.config` everywhere, instead of defining constant names? 

@andrewjgremmo--did I make the required changes in `TimeOffRequests.js` for prod? 