### PR TITLE
add batch deletions to delete all shifts request

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -51,7 +51,10 @@ config.time_interval = {
     days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7,
 
     // How often do we create new openshifts
-    open_shifts: '0 0 * * * *' // every hour
+    open_shifts: '0 0 * * * *', // every hour
+
+    // How often we repeat open shifts
+    days_in_interval_to_repeat_open_shifts: 7
 }
 
 config.mandrill = {

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -37,15 +37,46 @@ router.get('/cancel-shift', function(req, res) {
                 var q = {
                     user_id: users[i].id,
                     start: moment().format('YYYY-MM-DD 00:00:00'),
-                    end: moment([2050]).format('YYYY-MM-DD HH:mm:ss'),
+                    end: moment().add(50, 'years').format('YYYY-MM-DD HH:mm:ss'),
                     unpublished: true,
                     location_id: global.config.locationID.regular_shifts
                 };
 
+                // Works to delete the normal volume of shifts associated with one user (2 shifts), recurred
+                // over 50 years. API will break if significantly larger volumes of shifts are attempted
+                // to be deleted. 
                 api.get('shifts', q, function (shifts) {
+                    var batchPayload = [];
                     for (var i in shifts.shifts) {
-                        api.update('shifts/'+shifts.shifts[i].id, {user_id: 0});
+
+                        var shift = shifts.shifts[i];
+                        // If the shift starts within a week, it's a shift that needs to be converted to an 
+                        // open shift because the open shift job has already run and passed that day. 
+                        if (Math.abs(moment().diff(moment(shift.start_time), 'days')) < global.config.time_interval.days_in_interval_to_repeat_open_shifts) {
+                            var reassignShiftToOpenAndRemoveNotesRequest = {
+                                "method": 'PUT',
+                                "url": "/2/shifts/" + shift.id,
+                                "params": {
+                                    user_id: 0, 
+                                    notes: ''
+                                }   
+                            }
+                            batchPayload.push(reassignShiftToOpenAndRemoveNotesRequest);
+                        }
+                        // Otherwise, we just delete the shift. 
+                        else {
+                            var shiftDeleteRequest = {
+                                "method": "delete",
+                                "url": "/2/shifts/" + shift.id,
+                                "params": {},
+                            };
+                            batchPayload.push(shiftDeleteRequest);
+                        }
                     }
+                    api.post('batch', batchPayload, function(response) {
+                        console.log(response);
+                    })
+
                     var api2 = new WhenIWork(global.config.wheniwork.api_key, email, global.config.wheniwork.default_password);
 
                     api2.post('users/autologin', function (data) {
@@ -110,4 +141,3 @@ function checkUser(email, first, last, callback) {
 }
 
 module.exports = router;
-


### PR DESCRIPTION
#### What's this PR do?
Add batch shift deletions to the delete all shifts functionality. Note that it creates an open shift in the place of the upcoming shift (as per our philosophy of only opening up shifts one week from the present), and deletes the rest. 

#### How should this be manually tested?
Manually tested by creating two recurring shifts, extracting the function (starting on line 48), and running it using the Node REPL. Confirmed that shifts were deleted. 

#### Any background context you want to provide?
Note that this breaks on high volumes of shifts. (For instance, if a user recurred 24 shifts over five years.) Works with normal volumes: one user's two shifts, recurred over five years. 