### PR TITLE
Merge openshifts

### DIFF
--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -1,0 +1,65 @@
+
+var CronJob = require('cron').CronJob;
+var WhenIWork = require('./base');
+var moment = require('moment');
+
+var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+
+new CronJob('0 0 * * * *', function () {
+    mergeOpenShifts();
+});
+
+mergeOpenShifts();
+
+function mergeOpenShifts() {
+    var query = {
+        include_allopen: true,
+        start: moment().add(-1, 'days').format(wiw_date_format),
+        end: moment().add(7, 'days').format(wiw_date_format),
+        location_id: global.config.locationID.regular_shifts
+    };
+
+    WhenIWork.get('shifts', query, function (data) {
+        var open_shifts = {};
+
+        for (var i in data.shifts) {
+            if (data.shifts[i].is_open) {
+                var shift = data.shifts[i];
+
+                if (typeof open_shifts[shift.start_time] == 'undefined') {
+                    open_shifts[shift.start_time] = [];
+                }
+
+                open_shifts[shift.start_time].push(shift);
+            }
+        }
+
+        for (var i in open_shifts) {
+            if (open_shifts[i].length > 1) {
+                var shift = open_shifts[i];
+                var max = -1;
+                var instances = 0;
+
+                for (var j in shift) {
+                    if (shift[j].instances == undefined || shift[j].instances == 0) {
+                        instances += 1;
+                    } else {
+                        instances += shift[j].instances;
+
+                        if (shift[j].instances > max) {
+                            max = shift[j].instances;
+                        }
+                    }
+                }
+
+                for (var j in shift) {
+                    if (shift[j].instances !== undefined && shift[j].instances == max) {
+                        WhenIWork.update('shifts/'+shift[j].id, {instances: instances});
+                    } else {
+                        WhenIWork.delete('shifts/'+shift[j].id);
+                    }
+                }
+            }
+        }
+    });
+}

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -7,6 +7,8 @@ var router = express.Router();
 
 var api = new WhenIWork(global.config.wheniwork.api_key, global.config.wheniwork.username, global.config.wheniwork.password);
 
+var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+
 router.get('/login', function (req, res) {
     if (!validate(req.query.email, req.query.token)) {
         res.status(403).send('Access denied.');
@@ -58,7 +60,7 @@ router.get('/cancel-shift', function(req, res) {
                         var shift = shifts.shifts[i];
                         // If the shift starts within a week, it's a shift that needs to be converted to an 
                         // open shift because the open shift job has already run and passed that day. 
-                        if (Math.abs(moment().diff(moment(shift.start_time), 'days')) < global.config.time_interval.days_in_interval_to_repeat_open_shifts) {
+                        if (Math.abs(moment().diff(moment(shift.start_time, wiw_date_format), 'days')) < global.config.time_interval.days_in_interval_to_repeat_open_shifts) {
                             var reassignShiftToOpenAndRemoveNotesRequest = {
                                 "method": 'PUT',
                                 "url": "/2/shifts/" + shift.id,


### PR DESCRIPTION
### Background
When we create openshifts for a time period for which open shifts already exist, those open shifts aren't always automatically incremented by one. Instead, multiple open shifts will then exist in that time slot. 

This is functionally harmless, but potentially confusing for the user. 

### What does this PR do? 
This PR finds time slots for which there are multiple open shifts, and merges those shifts into one shift. (While incrementing the quantity on that one shift, so that it can represent multiple shifts.)