### PR TITLE
Autologin for shift cancellation

### DIFF
--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -85,10 +85,12 @@ router.get('/cancel-shift', function(req, res) {
                         console.log(response);
                     })
 
-                    var api2 = new WhenIWork(global.config.wheniwork.api_key, email, global.config.wheniwork.default_password);
+                    var api2 = new WhenIWork(global.config.wheniwork.api_key, email, global.config.wheniwork.default_password, function (resp) {
+                        res.render('scheduling/cancelShift', { url: 'https://app.wheniwork.com/' });
+                    });
 
                     api2.post('users/autologin', function (data) {
-                        res.render('scheduling/cancelShift', { token: data.hash });
+                        res.render('scheduling/cancelShift', { url: 'https://app.wheniwork.com/myschedule?al=' + data.hash });
                     });
                 });
 

--- a/www/views/scheduling/cancelShift.jade
+++ b/www/views/scheduling/cancelShift.jade
@@ -2,6 +2,5 @@ extends ../layout
 
 block content
     h1 Your shift has been permanently cancelled.
-    form(action="https://app.wheniwork.com/scheduler", method="get")
+    form(action="#{url}", method="get")
         input(type="submit", value="Continue on to schedule a new shift")
-        input(type="hidden", name="al", value="#{token}")


### PR DESCRIPTION
#### What's this PR do?
Currently, when a user goes to autologin to WhenIWork, we detect if it's an invalid username (their account wasn't created by us) and we redirect them to the login page accordingly.

However, this logic is not applying to the cancel shifts route. So, this PR adds the relevant `failureCallback` method to `api2`'s authentication call.

#### How should this be manually tested?
Attempt to cancel all shifts as a user with a manually created WiW account.