### PR TITLE
add individual deletion of shifts

### DIFF
--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -5,11 +5,11 @@ var fs = require('fs');
 
 var date_format = 'YYYY-MM-DD HH:mm:ss';
 
-// new CronJob(global.config.time_interval.time_off_requests_cron_job_string, function () {
-//     handleTimeOffRequests();
-// }, null, true);
+new CronJob(global.config.time_interval.time_off_requests_cron_job_string, function () {
+    handleTimeOffRequests();
+}, null, true);
 
-// handleTimeOffRequests();
+handleTimeOffRequests();
 
 function handleTimeOffRequests() {
     //Using moment.js to format time as WIW expects

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -5,11 +5,11 @@ var fs = require('fs');
 
 var date_format = 'YYYY-MM-DD HH:mm:ss';
 
-new CronJob(global.config.time_interval.time_off_requests_cron_job_string, function () {
-    handleTimeOffRequests();
-}, null, true);
+// new CronJob(global.config.time_interval.time_off_requests_cron_job_string, function () {
+//     handleTimeOffRequests();
+// }, null, true);
 
-handleTimeOffRequests();
+// handleTimeOffRequests();
 
 function handleTimeOffRequests() {
     //Using moment.js to format time as WIW expects

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jade": "~1.3.0",
     "mandrill-api": "^1.0.45",
     "moment": "^2.11.0",
+    "moment-timezone": "^0.5.0",
     "morgan": "~1.0.0",
     "require-all": "^2.0.0",
     "sha1": "^1.1.1",

--- a/www/public/javascripts/main.js
+++ b/www/public/javascripts/main.js
@@ -1,0 +1,11 @@
+$(document).ready(
+	function(){
+	    var max = 2;
+	    var checkboxes = $('input[type="checkbox"]');
+
+	    checkboxes.change(function(){
+	        var current = checkboxes.filter(':checked').length;
+	        checkboxes.filter(':not(:checked)').prop('disabled', current >= max);
+	    });
+	}
+)

--- a/www/public/javascripts/main.js
+++ b/www/public/javascripts/main.js
@@ -1,14 +1,13 @@
-var max = 2;
+var maxCheckedBoxes = 2; // Only two boxes can be checked at a given time. Restricting because of perceived WhenIWork API limits.
 var checkboxes = $('input[type="checkbox"]');
 
 checkboxes.change(function(){
-    var current = checkboxes.filter(':checked').length;
-    checkboxes.filter(':not(:checked)').prop('disabled', current >= max);
+    var currentBoxesChecked = checkboxes.filter(':checked').length;
+    checkboxes.filter(':not(:checked)').prop('disabled', currentBoxesChecked >= maxCheckedBoxes);
 });
 
 $("#delete-shifts").click(function(e){
     e.preventDefault();
-
     var deleteURL = "/scheduling/shifts?" + $("form[name=cancel-form]").serialize();
 
     $.ajax({

--- a/www/public/javascripts/main.js
+++ b/www/public/javascripts/main.js
@@ -1,11 +1,7 @@
-$(document).ready(
-	function(){
-	    var max = 2;
-	    var checkboxes = $('input[type="checkbox"]');
+var max = 2;
+var checkboxes = $('input[type="checkbox"]');
 
-	    checkboxes.change(function(){
-	        var current = checkboxes.filter(':checked').length;
-	        checkboxes.filter(':not(:checked)').prop('disabled', current >= max);
-	    });
-	}
-)
+checkboxes.change(function(){
+    var current = checkboxes.filter(':checked').length;
+    checkboxes.filter(':not(:checked)').prop('disabled', current >= max);
+});

--- a/www/public/javascripts/main.js
+++ b/www/public/javascripts/main.js
@@ -5,3 +5,17 @@ checkboxes.change(function(){
     var current = checkboxes.filter(':checked').length;
     checkboxes.filter(':not(:checked)').prop('disabled', current >= max);
 });
+
+$("#delete-shifts").click(function(e){
+    e.preventDefault();
+
+    var deleteURL = "/scheduling/shifts?" + $("form[name=cancel-form]").serialize();
+
+    $.ajax({
+        url: deleteURL,
+        type: "DELETE",
+        success: function(data) {
+            window.location = data.redirect;
+        }
+    });
+});

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -13,7 +13,7 @@ var choose_shift_to_cancel_page_start_date_format = 'dddd h:mm a';
 var choose_shift_to_cancel_page_end_date_format = 'h:mm a z'
 var schedule_shifts_url = 'https://app.wheniwork.com/login/?redirect=myschedule'
 
-router.get('/', function(req, res) {
+router.get('/shifts', function(req, res) {
     var email = req.query.email;
     if (!validate(req.query.email, req.query.token)) {
         res.status(403).send('Access denied.');
@@ -38,7 +38,7 @@ router.get('/', function(req, res) {
                 api.get('shifts', query, function(response) {
                     if (!response.shifts || !response.shifts.length) {
                         var error = "You don't seem to have booked any shifts to delete! If this message is sent in error, contact scheduling@crisistextline.org";
-                        res.render('scheduling/chooseShiftToCancel', { error: error , url: schedule_shifts_url});
+                        res.render('scheduling/chooseShiftToCancel', { error: error , url: schedule_shifts_url });
                         return;
                     }
                     var shifts = response.shifts;
@@ -73,8 +73,15 @@ router.get('/', function(req, res) {
                         shift.end_time = moment(shift.end_time, wiw_date_format).tz('America/New_York').format(choose_shift_to_cancel_page_end_date_format);
                     })
 
+                    var templateData = { 
+                        shifts: shifts, 
+                        userID: userID, 
+                        email: email, 
+                        token: req.query.token, 
+                        userName: userName
+                    }
                     // Then, display them in the jade template. 
-                    res.render('scheduling/chooseShiftToCancel', { shifts: shifts, userID: userID, email: email, token: req.query.token, userName: userName });
+                    res.render('scheduling/chooseShiftToCancel', templateData);
                 })
                 break;
             }
@@ -94,7 +101,7 @@ function areShiftsDuplicate(shiftA, shiftB) {
 }
 
 // Route which allows individual deletion of shifts
-router.post('/delete-shifts', function(req, res) {
+router.post('/shifts', function(req, res) {
     if (!validate(req.body.email, req.body.token)) {
         res.status(403).send('Access denied.');
     }

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -46,7 +46,7 @@ router.get('/', function(req, res) {
                     **/
                     shifts.forEach(function(shift) {
                         if (!shift.notes) {
-                            var error = "Please wait 30 seconds, and then refresh and try again.";
+                            var error = "Sorry! WhenIWork is loading slowly. Please wait 30 seconds, and then refresh and try again.";
                             res.render('scheduling/chooseShiftToCancel', { error: error , url: schedule_shifts_url});
                             return;
                         }
@@ -69,6 +69,8 @@ router.get('/', function(req, res) {
                         shift.start_time = moment(shift.start_time, wiw_date_format).tz('America/New_York').format(choose_shift_to_cancel_page_start_date_format);
                         shift.end_time = moment(shift.end_time, wiw_date_format).tz('America/New_York').format(choose_shift_to_cancel_page_end_date_format);
                     })
+
+
 
                     // Then, display them in the jade template. 
                     res.render('scheduling/chooseShiftToCancel', { shifts: shifts, userID: userID, email: email, token: req.query.token, userName: userName });
@@ -139,7 +141,9 @@ router.post('/delete-shifts', function(req, res) {
                 }
 
                 if (!deletedShiftInformation[parentShiftID]) {
-                    deletedShiftInformation[parentShiftID] = { start_time: shift.start_time, end_time: shift.end_time };
+                    var formattedStartTime = moment(shift.start_time, wiw_date_format).tz('America/New_York').format(choose_shift_to_cancel_page_start_date_format);
+                    var formattedEndTime = moment(shift.end_time, wiw_date_format).tz('America/New_York').format(choose_shift_to_cancel_page_end_date_format)
+                    deletedShiftInformation[parentShiftID] = { start_time: formattedStartTime, end_time: formattedEndTime };
                 }
             }
         })

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -14,7 +14,7 @@ var choose_shift_to_cancel_page_end_date_format = 'h:mm a z'
 var schedule_shifts_url = 'https://app.wheniwork.com/login/?redirect=myschedule'
 
 router.get('/', function(req, res) {
-    var email = req.email;
+    var email = req.query.email;
     if (!validate(req.query.email, req.query.token)) {
         res.status(403).send('Access denied.');
     }
@@ -22,8 +22,8 @@ router.get('/', function(req, res) {
     var altEmail = email.replace(/\W+/g, '');
     altEmail = 'admin+'+altEmail+'@crisistextline.org';
 
-    api.get('users', function (users) {
-        users = users.users;
+    api.get('users', function (dataResponse) {
+        var users = dataResponse.users;
         for (var i in users) {
             if (users[i].email == email || users[i].email == altEmail) {
                 var userName = users[i].first_name + ' ' + users[i].last_name;
@@ -158,7 +158,14 @@ router.post('/delete-shifts', function(req, res) {
 
         api.post('batch', batchPayload, function(response) {
             console.log('Shifts deleted response: \n', response);
-            res.render('scheduling/someShiftsCancelled', { deletedShiftInformation: deletedShiftInformation });
+            var templateData = { 
+                deletedShiftInformation: deletedShiftInformation, 
+                email: req.body.email, 
+                token: req.body.token, 
+                url: 'https://app.wheniwork.com/'
+            }
+
+            res.render('scheduling/someShiftsCancelled', templateData);
         })
     });
 })

--- a/www/views/layout.jade
+++ b/www/views/layout.jade
@@ -3,5 +3,7 @@ html
   head
     title= title
     link(rel='stylesheet', href='/stylesheets/style.css')
+    script(type='text/javascript', src='https://code.jquery.com/jquery-2.2.0.min.js')
+    script(type='text/javascript', src='/javascripts/main.js')
   body
     block content

--- a/www/views/layout.jade
+++ b/www/views/layout.jade
@@ -3,8 +3,8 @@ html
   head
     title= title
     link(rel='stylesheet', href='/stylesheets/style.css')
-    script(type='text/javascript', src='https://code.jquery.com/jquery-2.2.0.min.js')
   body
     block content
     block foot
+        script(type='text/javascript', src='https://code.jquery.com/jquery-2.2.0.min.js')
         script(type='text/javascript', src='/javascripts/main.js')

--- a/www/views/layout.jade
+++ b/www/views/layout.jade
@@ -4,6 +4,7 @@ html
     title= title
     link(rel='stylesheet', href='/stylesheets/style.css')
     script(type='text/javascript', src='https://code.jquery.com/jquery-2.2.0.min.js')
-    script(type='text/javascript', src='/javascripts/main.js')
   body
     block content
+    block foot
+        script(type='text/javascript', src='/javascripts/main.js')

--- a/www/views/scheduling/allShiftsCancelled.jade
+++ b/www/views/scheduling/allShiftsCancelled.jade
@@ -1,6 +1,6 @@
 extends ../layout
 
 block content
-    h1 Your shift has been permanently cancelled.
-    form(action="#{url}", method="get")
+    h1 Click on a shift to cancel it
+    form(action="#{url}", method="post")
         input(type="submit", value="Continue on to schedule a new shift")

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -1,0 +1,22 @@
+extends ../layout
+
+block content
+    - if (error) {
+        h3=error 
+        | #[a(href="#{url}") schedule another shift]
+    - }
+    - else if (shifts && shifts.length > 0) {
+        h1 Check a shift to delete it 
+        form(action="/scheduling/delete-shifts" , method="post")
+            input(type="hidden", name="email", value=email)
+            input(type="hidden", name="userID", value=userID)
+            input(type="hidden", name="token", value=token)
+            each shift in shifts
+                - var parentShiftID = JSON.parse(shift.notes).parent_shift
+                - var title = shift.start_time + ' to ' + shift.end_time
+                div.input
+                    input(type="checkbox", name=parentShiftID)
+                    span.label=title
+            div.actions
+                input(type="submit", value="delete checked shifts")
+    - }

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -2,13 +2,13 @@ extends ../layout
 
 block content
     - if (error) {
-        h3=error 
+        h3=error
         | #[a(href="#{url}") schedule another shift]
     - }
     - else if (shifts && shifts.length > 0) {
         h2 delete individual shifts - choose up to two shifts to delete at a time
         h4=userName + "'s shifts"
-        form(action="/scheduling/shifts" , method="post")
+        form(name="cancel-form")
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)
             input(type="hidden", name="token", value=token)
@@ -19,5 +19,5 @@ block content
                     input(type="checkbox", name=parentShiftID)
                     span.label=title
             div.actions
-                input(type="submit", value="delete checked shifts")
+                input(type="submit", id="delete-shifts")
     - }

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -8,7 +8,7 @@ block content
     - else if (shifts && shifts.length > 0) {
         h2 delete individual shifts - choose up to two shifts to delete at a time
         h4=userName + "'s shifts"
-        form(action="/scheduling/delete-shifts" , method="post")
+        form(action="/scheduling/shifts" , method="post")
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)
             input(type="hidden", name="token", value=token)

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -6,7 +6,8 @@ block content
         | #[a(href="#{url}") schedule another shift]
     - }
     - else if (shifts && shifts.length > 0) {
-        h1 Check a shift to delete it 
+        h2 Delete Individual Shifts
+        h4=userName + "'s shifts"
         form(action="/scheduling/delete-shifts" , method="post")
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -6,7 +6,7 @@ block content
         | #[a(href="#{url}") schedule another shift]
     - }
     - else if (shifts && shifts.length > 0) {
-        h2 Delete Individual Shifts
+        h2 delete individual shifts - choose up to two shifts to delete at a time
         h4=userName + "'s shifts"
         form(action="/scheduling/delete-shifts" , method="post")
             input(type="hidden", name="email", value=email)

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -1,10 +1,12 @@
 extends ../layout
 
 block content
-    h1 The following shifts have been successfully cancelled: 
+    h1 The following shifts have been successfully deleted: 
     ul
       each shift in deletedShiftInformation
         li=shift.start_time + ' to ' + shift.end_time
 
     form(action="#{url}", method="post")
         input(type="submit", value="Continue on to schedule a new shift")
+    form(action="/scheduling", method="get")
+        input(type="submit", value="Delete other shifts")

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -8,7 +8,7 @@ block content
 
     form(action="#{url}", method="post")
         input(type="submit", value="Continue on to schedule a new shift")
-    form(action="/scheduling", method="get")
+    form(action="/scheduling/shifts", method="get")
         input(type="hidden", name="email", value=email)
         input(type="hidden", name="token", value=token)
         input(type="submit", value="Delete other shifts")

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -9,4 +9,6 @@ block content
     form(action="#{url}", method="post")
         input(type="submit", value="Continue on to schedule a new shift")
     form(action="/scheduling", method="get")
+        input(type="hidden", name="email", value=email)
+        input(type="hidden", name="token", value=token)
         input(type="submit", value="Delete other shifts")

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -1,0 +1,10 @@
+extends ../layout
+
+block content
+    h1 The following shifts have been successfully cancelled: 
+    ul
+      each shift in deletedShiftInformation
+        li= shift.start_time + ' to ' + shift.end_time
+
+    form(action="#{url}", method="post")
+        input(type="submit", value="Continue on to schedule a new shift")

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -4,7 +4,7 @@ block content
     h1 The following shifts have been successfully cancelled: 
     ul
       each shift in deletedShiftInformation
-        li= shift.start_time + ' to ' + shift.end_time
+        li=shift.start_time + ' to ' + shift.end_time
 
     form(action="#{url}", method="post")
         input(type="submit", value="Continue on to schedule a new shift")

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -1,7 +1,8 @@
 extends ../layout
 
 block content
-    h1 The following shifts have been successfully deleted: 
+    h1 The following shifts have been successfully deleted:
+    - deletedShiftInformation = JSON.parse(deletedShiftInformation)
     ul
       each shift in deletedShiftInformation
         li=shift.start_time + ' to ' + shift.end_time


### PR DESCRIPTION
#### What's this PR do?
1. adds the individual deletion of shifts functionality to Elmer. 
2. Also removes the bulk deletion route of shifts. 

#### What's the user flow? 
1. When the user navigates to online.crisistextline.org/schedules, she'll see a new button to the page which says "drop individual shifts" (to be added.) 
2. Clicking this button will GET the `/scheduling` route on Elmer, displaying a page which lists all the user's shifts in a checkbox form. Only two checkboxes are able to be checked at one time, roughly reflecting WhenIWork's API limit. 
3. When the user checks a shift's box and submits the form, we POST to the `/delete-shifts` route. 
4. The user is redirected to a new view: `someShiftsCancelled.jade`, which then gives a link for the user to be redirected back to When I Work, so that they can schedule another shift. 

#### How should this be manually tested?
Note below that the app crashes upon a successful delete shift request, so we can't confirm that the final page is displayed. 

Currently has been tested by scheduling two shifts in the `test` location on WiW, then deleting them together or individually with Elmer after commenting out the checks for a valid email and token. 
#### Background:
**note 1**
**TODO**: Currently, our successful delete-shift batch requests consistently return with an 502 error encoded in HTML in the body of the response. But this breaks line 159 within `index.js` of the module `wheniwwork_unofficial`. We need to resolve this--a crappy solution that might be the best solution would be to add a check for HTML on line 159. 

Currently, this crashing breaks the redirect after shifts are cancelled. 

**note 2**
Since the shift recurrence cronjob currently runs every minute, it's possible that a user books shifts and attempts to delete them before the shift recurrence cronjob has successfully recurred that shift. 

If this happens, the shifts won't delete--much of the shift deletion logic relies on the `notes.parent_shift` param, which is only added during shift recurrence--and instead the user will be redirected to an error message telling her to wait 30 seconds and then try again. 

