### PR TITLE
fix crash caused by timeoff requests not including shifts within their range

### DIFF
--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -42,6 +42,11 @@ function handleTimeOffRequests() {
             };
 
             WhenIWork.get('shifts', shiftSearchParams, function(response) {
+                if (!response.shifts || response.shifts.length === 0) {
+                    console.log('No shifts found that fall within the range of timeoff request.');
+                    return false;
+                }
+
                 // Status code `2` represents approved requests.
                 var timeOffApprovalRequest = {
                     "method": "put",


### PR DESCRIPTION
#### What's this PR do?
If a user creates a timeoff request, but she has not scheduled any shifts during that timeoff range, this no longer crashes the app. 

(previously would break at `response.shifts.forEach(function(shift) {`. 

#### How should this be manually tested?
Manually tested by creating a timeoff request not containing any shifts within its scope, and running. 

#### What are the relevant tickets?
Closes #26. 