### PR TITLE
Openshifts

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -22,22 +22,22 @@ config.locationID = {
 }
 
 config.time_interval = {
-    // runs every 1 min. 
+    // runs every 1 min.
     recur_and_publish_shifts_cron_job_string: '0 */1 * * * *',
 
-    // runs every 20 mins. 
+    // runs every 20 mins.
     notify_first_shift_cron_job_string: '0 */20 * * * *',
 
-    // runs every day at 11:00 and 23:00. 
+    // runs every day at 11:00 and 23:00.
     time_off_requests_cron_job_string: '0 0 11,23 * * *',
 
-    // Each recurrence chain is 1 year long. 
+    // Each recurrence chain is 1 year long.
     max_shifts_in_chain: 52,
-    
-    // Buffer added to end of chain to ensure that edge cases don't result in skipped weeks. 
+
+    // Buffer added to end of chain to ensure that edge cases don't result in skipped weeks.
     chain_buffer_days: 1,
 
-    // Each shift is recurred for 5 years. 
+    // Each shift is recurred for 5 years.
     years_to_recur_shift: 5,
 
     // In looking for newly created shifts to recur, we search 2 weeks from the present.
@@ -46,13 +46,13 @@ config.time_interval = {
     // While we recur shifts for much longer, they're only published (viewable to the employee) 4 weeks from present.
     weeks_to_publish_recurred_shifts: 4,
 
-    // Used to search for requests to be auto-approved. 
+    // Used to search for requests to be auto-approved.
     months_to_search_for_time_off_requests: 6,
 
-    // Used to search for users in order to notify them via email.  
+    // Used to search for users in order to notify them via email.
     days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7,
 
-    // How often do we create new openshifts
+    // How often do we create new openshifts and merge duplicate openshifts
     open_shifts: '0 0 * * * *', // every hour
 
     // How often we repeat open shifts

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -38,6 +38,7 @@ function mergeOpenShifts() {
                 var shift = open_shifts[i];
                 var max = -1;
                 var instances = 0;
+                var remainingShiftUpdated = false;
 
                 for (var j in shift) {
                     if (shift[j].instances == undefined || shift[j].instances == 0) {
@@ -52,8 +53,9 @@ function mergeOpenShifts() {
                 }
 
                 for (var j in shift) {
-                    if (shift[j].instances !== undefined && shift[j].instances == max) {
+                    if (shift[j].instances !== undefined && shift[j].instances == max && !remainingShiftUpdated) {
                         WhenIWork.update('shifts/'+shift[j].id, {instances: instances});
+                        remainingShiftUpdated = true;
                     } else {
                         WhenIWork.delete('shifts/'+shift[j].id);
                     }

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -4,7 +4,7 @@ var WhenIWork = require('./base');
 
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-new CronJob('0 0 * * * *', function () {
+new CronJob(global.config.time_interval.open_shifts, function () {
     mergeOpenShifts();
 });
 
@@ -19,23 +19,23 @@ function mergeOpenShifts() {
     };
 
     WhenIWork.get('shifts', query, function (data) {
-        var open_shifts = {};
+        var openShifts = {};
 
         for (var i in data.shifts) {
             if (data.shifts[i].is_open) {
                 var shift = data.shifts[i];
 
-                if (typeof open_shifts[shift.start_time] == 'undefined') {
-                    open_shifts[shift.start_time] = [];
+                if (typeof openShifts[shift.start_time] == 'undefined') {
+                    openShifts[shift.start_time] = [];
                 }
 
-                open_shifts[shift.start_time].push(shift);
+                openShifts[shift.start_time].push(shift);
             }
         }
 
-        for (var i in open_shifts) {
-            if (open_shifts[i].length > 1) {
-                var shift = open_shifts[i];
+        for (var i in openShifts) {
+            if (openShifts[i].length > 1) {
+                var shift = openShifts[i];
                 var max = -1;
                 var instances = 0;
                 var remainingShiftUpdated = false;


### PR DESCRIPTION
#### What's this PR do?
Previously, our `MergeOpenShifts` job exponentially increased the `instances` number on an openshifts. 

(If two openshifts had the same `instances` number, they'd both get updated with the new instances number and neither would be deleted. So if we begin with two open shifts, each with an instance number of 1, they'd both be updated to 2, then 4, then 8, then 16--each time the cron job runs once an hour.)

This fixes this problem with a flag. Also adds some camelCase, fixes whitespaces, and moves the cronjob string out into the global config. 