### PR TITLE
add revised open shift recurrence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ config.js
 !.elasticbeanstalk/*.global.yml
 
 *.csv
+*.swp

--- a/config.js.default
+++ b/config.js.default
@@ -19,7 +19,7 @@ config.locationID = {
     test2: 1007104,
     supervisors: 884473,
     crisis_counselors_demo: 1004215
-}
+};
 
 config.time_interval = {
     // runs every 1 min.
@@ -53,11 +53,11 @@ config.time_interval = {
     days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7,
 
     // How often do we create new openshifts and merge duplicate openshifts
-    open_shifts: '0 0 * * * *', // every hour
+    open_shifts: '0 0 */2 * * *', // every two hours
 
     // How often we repeat open shifts
     days_in_interval_to_repeat_open_shifts: 7
-}
+};
 
 config.mandrill = {
     api_key: 'TODO'
@@ -71,13 +71,14 @@ config.stathat = {
 config.numberOfCrisisCounselorsPerSupervisor = 15;
 
 config.numberOfSupervisorsPerShift = {
-    '0_Sun' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 3, '6PM': 3, '8PM': 3, '10PM': 3},
-    '1_Mon' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
-    '2_Tue' : { '12AM': 3, '2AM': 3, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
-    '3_Wed' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
-    '4_Thu' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 3, '2PM': 3, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
-    '5_Fri' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 5, '6PM': 5, '8PM': 4, '10PM': 4},
-    '6_Sat' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 5, '6PM': 5, '8PM': 4, '10PM': 4}
-}
+    'Sun' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 3, '6pm': 3, '8pm': 3, '10pm': 3},
+    'Mon' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Tue' : { '12am': 3, '2am': 3, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Wed' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Thu' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 3, '2pm': 3, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Fri' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 5, '6pm': 5, '8pm': 4, '10pm': 4},
+    'Sat' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 5, '6pm': 5, '8pm': 4, '10pm': 4}
+};
+
 
 module.exports = config;

--- a/config.js.default
+++ b/config.js.default
@@ -68,16 +68,16 @@ config.stathat = {
     email: 'todo'
 };
 
-config.numberOfCrisisCounselorsPerSupervisor = 15;
+config.crisisCounselorsPerSupervisor = 15;
 
 config.numberOfSupervisorsPerShift = {
     'Sun' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 3, '6pm': 3, '8pm': 3, '10pm': 3},
-    'Mon' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
-    'Tue' : { '12am': 3, '2am': 3, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
-    'Wed' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
-    'Thu' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 3, '2pm': 3, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
-    'Fri' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 5, '6pm': 5, '8pm': 4, '10pm': 4},
-    'Sat' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 5, '6pm': 5, '8pm': 4, '10pm': 4}
+    'Mon' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 3, '10pm': 3},
+    'Tue' : { '12am': 2, '2am': 2, '4am': 1, '6am': 1, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Wed' : { '12am': 2, '2am': 2, '4am': 1, '6am': 1, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Thu' : { '12am': 2, '2am': 2, '4am': 1, '6am': 1, '8am': 2, '10am': 2, '12pm': 3, '2pm': 3, '4pm': 4, '6pm': 4, '8pm': 4, '10pm': 4},
+    'Fri' : { '12am': 2, '2am': 2, '4am': 2, '6am': 2, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 5, '6pm': 5, '8pm': 3, '10pm': 3},
+    'Sat' : { '12am': 2, '2am': 2, '4am': 1, '6am': 1, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 3, '6pm': 3, '8pm': 3, '10pm': 3}
 };
 
 

--- a/config.js.default
+++ b/config.js.default
@@ -68,4 +68,16 @@ config.stathat = {
     email: 'todo'
 };
 
+config.numberOfCrisisCounselorsPerSupervisor = 15;
+
+config.numberOfSupervisorsPerShift = {
+    '0_Sun' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 3, '6PM': 3, '8PM': 3, '10PM': 3},
+    '1_Mon' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
+    '2_Tue' : { '12AM': 3, '2AM': 3, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
+    '3_Wed' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
+    '4_Thu' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 3, '2PM': 3, '4PM': 4, '6PM': 4, '8PM': 4, '10PM': 4},
+    '5_Fri' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 5, '6PM': 5, '8PM': 4, '10PM': 4},
+    '6_Sat' : { '12AM': 2, '2AM': 2, '4AM': 2, '6AM': 2, '8AM': 2, '10AM': 2, '12PM': 2, '2PM': 2, '4PM': 5, '6PM': 5, '8PM': 4, '10PM': 4}
+}
+
 module.exports = config;

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -37,8 +37,8 @@ function getCountOfOccupiedShiftsForTime(targetTimeMomentObj, callback) {
     // time taken off (and a shift removed from the normal schedule) will artificially
     // increase the number of open shifts we add.
     var filter = {
-        start: targetTimeMomentObj.clone().add(12, 'weeks').format(shiftQueryDateFormat),
-        end: targetTimeMomentObj.clone().add(12, 'weeks').add(1, 'minute').format(shiftQueryDateFormat),
+        start: targetTimeMomentObj.clone().add(10, 'weeks').format(shiftQueryDateFormat),
+        end: targetTimeMomentObj.clone().add(10, 'weeks').add(1, 'minute').format(shiftQueryDateFormat),
         include_allopen: true,
         location_id: global.config.locationID.regular_shifts
     };

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -13,13 +13,13 @@ var copy_fields = [
     'break_time',
     'alerted',
     'published'
-];    
+];
 
 new CronJob(global.config.time_interval.open_shifts, function () {
-    openShifts();
+    recurOpenShifts();
 }, null, true);
 
-function openShifts() {
+function recurOpenShifts() {
     // Example time filter: 1:59:00 pm - 2:01:00 pm
     var filter = {
         // start time = the top of the current hour -1 minute
@@ -62,4 +62,4 @@ function hourMatches(time) {
     return now == time;
 }
 
-module.exports.openShifts = openShifts;
+module.exports.recurOpenShifts = recurOpenShifts;

--- a/tasks/recur.js
+++ b/tasks/recur.js
@@ -1,0 +1,14 @@
+var recurrer = require('../jobs/scheduling/RecurOpenShifts');
+var moment = require('moment');
+
+console.log(global.config.crisisCounselorsPerSupervisor);
+
+module.exports.recurFromUnixTimestamp = function (from, to) {
+  from = parseInt(from);
+  to = parseInt(to);
+
+  for (var i = from; i <= to; i += 1000*60*60*2) {
+    var t = moment(i);
+    recurrer.recurOpenShifts(t);
+  }
+};

--- a/tasks/recur.js
+++ b/tasks/recur.js
@@ -1,14 +1,9 @@
 var recurrer = require('../jobs/scheduling/RecurOpenShifts');
 var moment = require('moment');
 
-console.log(global.config.crisisCounselorsPerSupervisor);
-
-module.exports.recurFromUnixTimestamp = function (from, to) {
+module.exports.recurFromUnixTimestamp = function (from) {
   from = parseInt(from);
-  to = parseInt(to);
 
-  for (var i = from; i <= to; i += 1000*60*60*2) {
-    var t = moment(i);
-    recurrer.recurOpenShifts(t);
-  }
+  var t = moment(from);
+  recurrer.recurOpenShifts(t);
 };


### PR DESCRIPTION
#### What's this PR do?
Adds open shift recurrence based on a new model: 

1. Create a config file listing the number of shifts available for specific times (perhaps listed as a multiple of the number of `counselors_per_supervisor`)
2. revise recurrence job so that it runs every so often
3. master scheduling doc + WiW Shift Sums tab (link here: https://docs.google.com/spreadsheets/d/120A2OqHk5XG62-b4Xai0LeWiEBzpQbgmLpQRXvoP5XQ/edit#gid=685762792) 
4. What does function do? 
5. check config file
6. runs every two hours, pulls all shifts which start between 2 and 2:01 (start and end params are referring to the start and end times for the START TIME of the shift, not the whole shift itself.) 
7. finds all shifts for that time period for the regular shifts location (NOT including makeup shifts, which we want to save for Nan as a wildcard. So she can adjust the number of shifts all the time.) 
8. total - current_number_of_shifts = open shifts to be added to that same shift time next week. 
9. checks to see if open shifts have already been added to that time period. 
9. if those shifts haven't already been added, add those shifts.

It runs every two hours, duplicating previous shift, but also checking previous couple of shifts (for fail-safe-ing. In case the system goes down or misses an hour.) 

#### Where should the reviewer start?

Check out config changes in `config.default.js` first. Then all the good stuff happens in `RecurOpenshifts.js`. 

#### How should this be manually tested?
Requires a few modifications to manually test. 
1. From `config.js.default`, add the objects for `numberOfSupervisorsPerShift` and `crisisCounselorsPerSupervisor` to the `config.js` file. 
2. Within `recurOpenShifts.js`, we need to specify which (even) hour we're running the script on. Comment out `var now = moment().minute(0).second(0);`, and add `var now = moment().hour(6).minute(0.second(0)`. 
3. Finally add a `recurOpenShifts()` function call. 

To run the entire Elmer app is to run a lot of the other jobs at the same time. To just run this job, we copy and paste the `config.js` file into `base.js` above the other code, along with `global.config = config` at the end of the config code. 

Finally, run `node /path/to/recurOpenShifts.js`. 

#### Any background context you want to provide?
Tested lightly. Needs to be tested heavily before merge. 

#### What are the relevant tickets?
Closes [Jira INT-3](https://admin.crisistextline.org/jira/browse/INT-3).

#### Questions: