### PR TITLE
refactor open shift recurrence so that incorrect number of open shits are deleted

### DIFF
--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -3,6 +3,8 @@ var WhenIWork = require.main.require('wheniwork-unofficial');
 var moment    = require.main.require('moment');
 var sha1      = require.main.require('sha1');
 var stathat   = require(global.config.root_dir + '/lib/stathat');
+var colorizeShift = require('../../lib/ColorizeShift');
+
 
 var router = express.Router();
 
@@ -137,14 +139,16 @@ router.delete('/shifts', function(req, res) {
                 // If the shift starts within a week, it's a shift that needs to be converted to an
                 // open shift because the open shift job has already run and passed that day.
                 if (Math.abs(moment().diff(moment(shift.start_time, wiwDateFormat), 'days')) < global.config.time_interval.days_in_interval_to_repeat_open_shifts) {
+                    var updatedShiftParams = {
+                        user_id: 0,
+                        notes: ''
+                    };
+                    updatedShiftParams = colorizeShift(updatedShiftParams, shift.start_time);
                     var reassignShiftToOpenAndRemoveNotesRequest = {
                         "method": 'PUT',
                         "url": "/2/shifts/" + shift.id,
-                        "params": {
-                            user_id: 0,
-                            notes: ''
-                        }
-                    }
+                        "params": updatedShiftParams
+                    };
                     batchPayload.push(reassignShiftToOpenAndRemoveNotesRequest);
                 }
                 // Otherwise, we just delete the shift.


### PR DESCRIPTION
#### What's this PR do?
Refactors open shift recurrence: 
1. We check to see if open shifts have already been recurred for the next week
2. Check if the number of open shifts matches up to the correct number of open shifts
3. If the numbers don't match, we delete the open shifts and add the correct number again

#### How should this be manually tested?
Tested by running job on test WhenIWork environment. 

#### What are the relevant tickets?
Closes [JIRA INT-10](https://admin.crisistextline.org/jira/browse/INT-10). 
#### Questions:
1. Think through all delete shift / open shift creation cases. Think about if this works with edge cases. 