### PR TITLE
Colorize recurred and merged shifts

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -80,5 +80,15 @@ config.numberOfSupervisorsPerShift = {
     'Sat' : { '12am': 2, '2am': 2, '4am': 1, '6am': 1, '8am': 2, '10am': 2, '12pm': 2, '2pm': 2, '4pm': 3, '6pm': 3, '8pm': 3, '10pm': 3}
 };
 
+var red = 'D61F27';
+config.shiftColors = {
+    'Sun': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Mon': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Tue': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Wed': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Thu': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Fri': { '2am': red, '4am': red, '6am': red, '8am': red },
+    'Sat': { '2am': red, '4am': red, '6am': red, '8am': red },
+};
 
 module.exports = config;

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -1,7 +1,7 @@
 
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
-var colorizeShift = require('../../lib/colorizeShift');
+var colorizeShift = require('../../lib/ColorizeShift');
 
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -1,6 +1,7 @@
 
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
+var colorizeShift = require('../../lib/colorizeShift');
 
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
@@ -54,7 +55,11 @@ function mergeOpenShifts() {
 
                 for (var j in shift) {
                     if (shift[j].instances !== undefined && shift[j].instances == max && !remainingShiftUpdated) {
-                        WhenIWork.update('shifts/'+shift[j].id, {instances: instances});
+                        var update = {instances: instances};
+                        update = colorizeShift(update, shift[j].start_time);
+
+                        WhenIWork.update('shifts/'+shift[j].id, update);
+
                         remainingShiftUpdated = true;
                     } else {
                         WhenIWork.delete('shifts/'+shift[j].id);

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -1,6 +1,7 @@
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
 var moment = require('moment');
+var colorizeShift = require('../../lib/colorizeShift');
 
 var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 var shiftQueryDateFormat = 'YYYY-MM-DD HH:mm:ss';
@@ -99,6 +100,7 @@ function addOpenShifts(numberOfOpenShiftsToAdd, targetTimeMomentObj) {
         instances: numberOfOpenShiftsToAdd,
         published: true
     };
+    newShiftParams = colorizeShift(newShiftParams);
     WhenIWork.create('shifts/', newShiftParams);
 }
 

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -1,7 +1,7 @@
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
 var moment = require('moment');
-var colorizeShift = require('../../lib/colorizeShift');
+var colorizeShift = require('../../lib/ColorizeShift');
 
 var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 var shiftQueryDateFormat = 'YYYY-MM-DD HH:mm:ss';

--- a/lib/ColorizeShift.js
+++ b/lib/ColorizeShift.js
@@ -1,0 +1,26 @@
+var moment = require('moment');
+var colors = require('../config').shiftColors;
+var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+
+/**
+ * If start_time is undefined, this function will search the
+ * shiftToColorize for start_time. Otherwise, for the case where
+ * we're doing a shift update and therefore not passing in an
+ * entire shift, we will check the second parameter.
+ */
+module.exports = function(shiftToColorize, startTime) {
+    if (typeof startTime == 'undefined') {
+        startTime = moment(shiftToColorize.start_time, WIWDateFormat);
+    } else {
+        startTime = moment(startTime, WIWDateFormat);
+    }
+
+    var day = startTime.format('ddd');
+    var time = startTime.format('ha');
+
+    if (colors[day] && colors[day][time]) {
+        shiftToColorize.color = colors[day][time];
+    }
+
+    return shiftToColorize;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 // TODO: pick an assertion library. @tong!
-var c = require('./lib/ColorizeShift.js');
+var c = require('../lib/ColorizeShift');
 var df = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 var moment = require('moment');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,20 @@
+// TODO: pick an assertion library. @tong!
+var c = require('./lib/ColorizeShift.js');
+var df = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+var moment = require('moment');
+
+var t1 = moment(1456995600000);
+var t2 = moment(1457017200000);
+
+var s1 = {
+    start_time: t1.format(df)
+};
+
+var s2 = {
+    start_time: t2.format(df)
+};
+
+console.log(c(s1));
+console.log(c(s2));
+console.log(c({}, t1));
+console.log(c({}, t2));


### PR DESCRIPTION
This PR should import a new library called ColorizeShift for use anywhere in the codebase. For now, it is required to explicitly call it. In the future, it may be possible to modify the wheniwork_nodejs library to support middleware, but this will do for now.

If a shift is defined in the config file, it will add a `color` property to the shift and return the new shift. Otherwise, it will just return the shift passed to it.