### PR TITLE
darken gray color of open shifts

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -84,8 +84,8 @@ config.numberOfSupervisorsPerShift = {
 };
 
 var red  = 'D61F27';
-var gray = 'AAAAAA';
-config.shiftColors = { 
+var gray = '5e5e5e';
+config.shiftColors = {
     'Sun': { '12am': gray, '2am': red, '4am': red, '6am': red, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': gray },
     'Mon': { '12am': gray, '2am': red, '4am': red, '6am': red, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': gray },
     'Tue': { '12am': gray, '2am': red, '4am': red, '6am': red, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': gray },


### PR DESCRIPTION
#### What's this PR do?
Darkens the gray color of non-red shifts in the `regular_shifts` location. Need to add this to the `config.js` file after this is deployed. 