### PR TITLE
move require() statement closer to top of first module loaded in

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,13 @@
 global.config = require('./config');
+require('newrelic');
 
-if (process.env.NODE_ENV === 'production') {
-    require('newrelic');
-}
-else {
-    global.config.locationID.regular_shifts = global.config.locationID.test;
+if (process.env.NODE_ENV !== 'production') {
+	global.config.locationID.regular_shifts = global.config.locationID.test;
 }
 
 var debug = require('debug')('my-application');
 var app = require('./www/app');
-var jobs = require('require-all')(__dirname + '/jobs');
+// var jobs = require('require-all')(__dirname + '/jobs');
 
 app.set('port', process.env.PORT || 3000);
 


### PR DESCRIPTION
Otherwise, new relic doesn't report. 