### PR TITLE
Add makeup shift deletion functionality

### DIFF
--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -5,19 +5,29 @@ block content
         h3=error
         | #[a(href="#{url}") schedule another shift]
     - }
-    - else if (shifts && shifts.length > 0) {
-        h2 delete individual shifts - choose up to two shifts to delete at a time
-        h4=userName + "'s shifts"
+    - else if (regularShifts && regularShifts.length > 0) {
+        h2=userName + "'s shifts"
+        h3 delete individual shifts - choose up to two shifts to delete at a time
+        h4 regular weekly shifts
         form(name="cancel-form")
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)
             input(type="hidden", name="token", value=token)
-            each shift in shifts
+            each shift in regularShifts
                 - var parentShiftID = JSON.parse(shift.notes).parent_shift
                 - var title = shift.start_time + ' to ' + shift.end_time
                 div.input
                     input(type="checkbox", name=parentShiftID)
                     span.label=title
+            - if (makeupShifts && makeupShifts.length > 0) {
+                h4 one-time makeup shifts
+                each shift in makeupShifts
+                    - var parentShiftID = 'makeupShift'
+                    - var title = shift.start_time + ' to ' + shift.end_time
+                    div.input
+                        input(type="checkbox", name=parentShiftID)
+                        span.label=title
+            - }
             div.actions
                 input(type="submit", id="delete-shifts")
     - }

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -13,11 +13,12 @@ block content
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)
             input(type="hidden", name="token", value=token)
+            input(type="hidden", name="userName", value=userName)
             each shift in regularShifts
                 - var parentShiftID = JSON.parse(shift.notes).parent_shift
                 - var title = shift.start_time + ' to ' + shift.end_time
                 div.input
-                    input(type="checkbox", name=parentShiftID)
+                    input(type="checkbox", name='regShift' + parentShiftID)
                     span.label=title
             - if (makeupShifts && makeupShifts.length > 0) {
                 h4 one-time makeup shifts
@@ -25,7 +26,7 @@ block content
                     - var parentShiftID = 'makeupShift'
                     - var title = shift.start_time + ' to ' + shift.end_time
                     div.input
-                        input(type="checkbox", name=parentShiftID)
+                        input(type="checkbox", name='makShift' + shift.id)
                         span.label=title
             - }
             div.actions

--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -2,15 +2,26 @@ extends ../layout
 
 block content
     h1 The following shifts have been successfully deleted:
-    - deletedShiftInformation = JSON.parse(deletedShiftInformation)
-    ul
-      each shift in deletedShiftInformation
-        li=shift.start_time + ' to ' + shift.end_time
+
+    - if (regShifts.length > 0) {
+        h4 regular weekly shifts deleted
+        ul
+            each shift in regShifts
+                li=shift.start_time + ' to ' + shift.end_time
+    - }
+
+    - if (makShifts.length > 0) {
+        h4 one-time makeup shifts deleted
+        ul
+            each shift in makShifts
+                li=shift.start_time + ' to ' + shift.end_time
+    - }
 
     form(action="#{url}", method="get")
         input(type="hidden", name="email", value=email)
         input(type="hidden", name="token", value=token)
         input(type="submit", value="Continue on to schedule a new shift")
+
     form(action="/scheduling/shifts", method="get")
         input(type="hidden", name="email", value=email)
         input(type="hidden", name="token", value=token)


### PR DESCRIPTION
#### What's this PR do?
Adds makeup shift deletion functionality. 

#### Where should the reviewer start?
Core logic happens in `www/routes/scheduling/index.js`. 

#### How should this be manually tested?
Running `node app.js` on your local box without passing any `NODE_ENV` env variables will make this run in the test environment, and the default `regular_shifts` location the test location. 

Within WhenIWork, pick up some shifts from both the makeup shifts and test locations. Then, navigate to 
`http://localhost:3000/scheduling/shifts?email=<email>&token=<token>` and then delete some shifts, homie!

#### Questions:
Currently, API calls take a long time--considering decreasing search field for first API call from 365 days? 

Also--add a spinning wheel between when call is made and when it happens. 