### PR TITLE
add task to delete all unpublished open shifts

### DIFF
--- a/tasks/deleteOpenUnpubShifts.js
+++ b/tasks/deleteOpenUnpubShifts.js
@@ -1,0 +1,31 @@
+var WhenIWork = require('wheniwork-unofficial');
+var api = new WhenIWork(global.config.wheniwork.api_key, global.config.wheniwork.username, global.config.wheniwork.password);
+
+module.exports.go = function() {
+    for (var i = 0; i < 365; i+=7) {
+        var postData = {
+                            "include_open": true,
+                            "location_id": global.config.locationID.regular_shifts,
+                            "start": '+' + i + ' days',
+                            "end": '+' + (i+7) + ' days',
+                            "unpublished": true
+                        };
+        var batchRequest = [];
+        api.get('shifts', postData, function(response) {
+            response.shifts.forEach(function(shift) {
+                if (shift.is_open && !shift.published) {
+                    var shiftDeleteRequest = {
+                        "method": "delete",
+                        "url": "/2/shifts/" + shift.id,
+                        "params": {},
+                    };
+                    batchRequest.push(shiftDeleteRequest);
+                }
+            })
+
+            api.post('batch', batchRequest, function(response) {
+                console.log(response);
+            })
+        })
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Adds a task to delete all unpublished open shifts. (This was likely causing the problem where we'd see a lot of unpublished open shifts.) 