### PR TITLE
colorize makeup shifts created by timeoff requests, refactor `colorizeShift` accordingly

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ global.config = require('./config');
 require('newrelic');
 
 if (process.env.NODE_ENV !== 'production') {
-	global.config.locationID.regular_shifts = global.config.locationID.test;
+    global.config.locationID.regular_shifts = global.config.locationID.test;
+    global.config.locationID.makeup_and_extra_shifts = global.config.locationID.test2;
 }
 
 var debug = require('debug')('my-application');

--- a/config.js.default
+++ b/config.js.default
@@ -85,22 +85,20 @@ config.numberOfCounselorsPerShift = {
     'Sat' : { '12am': 069, '2am': 040, '4am': 021, '6am': 011, '8am': 009, '10am': 019, '12pm': 023, '2pm': 030, '4pm': 040, '6pm': 045, '8pm': 057, '10pm': 071}
 };
 
-var red  = 'D61F27';
-var gray = '5e5e5e';
 config.shiftColors = {
-    'Sun': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': red },
+    'Sun': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'gray', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'red' },
 
-    'Mon': { '12am': red, '2am': red, '4am': red, '6am': red, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': red },
+    'Mon': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'red', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'gray', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'red' },
 
-    'Tue': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': red, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': red },
+    'Tue': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'red', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'red' },
 
-    'Wed': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': gray },
+    'Wed': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'gray', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'gray' },
 
-    'Thu': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': gray },
+    'Thu': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'gray', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'gray' },
 
-    'Fri': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': red, '4pm': gray, '6pm': gray, '8pm': gray, '10pm': red },
+    'Fri': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'red', '4pm': 'gray', '6pm': 'gray', '8pm': 'gray', '10pm': 'red' },
 
-    'Sat': { '12am': red, '2am': red, '4am': red, '6am': gray, '8am': gray, '10am': gray, '12pm': gray, '2pm': gray, '4pm': red, '6pm': red, '8pm': red, '10pm': red }
+    'Sat': { '12am': 'red', '2am': 'red', '4am': 'red', '6am': 'gray', '8am': 'gray', '10am': 'gray', '12pm': 'gray', '2pm': 'gray', '4pm': 'red', '6pm': 'red', '8pm': 'red', '10pm': 'red' }
 };
 
 module.exports = config;

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -1,7 +1,7 @@
 
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
-var colorizeShift = require('../../lib/ColorizeShift');
+var returnColorizedShift = require('../../lib/ColorizeShift');
 
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
@@ -56,7 +56,7 @@ function mergeOpenShifts() {
                 for (var j in shift) {
                     if (shift[j].instances !== undefined && shift[j].instances == max && !remainingShiftUpdated) {
                         var update = {instances: instances};
-                        update = colorizeShift(update, shift[j].start_time);
+                        update = returnColorizedShift(update, shift[j].start_time);
 
                         WhenIWork.update('shifts/'+shift[j].id, update);
 

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -1,7 +1,9 @@
-var CronJob = require('cron').CronJob;
-var WhenIWork = require('./base');
-var moment = require('moment-timezone');
-var fs = require('fs');
+var CronJob = require('cron').CronJob
+  , WhenIWork = require('./base')
+  , moment = require('moment-timezone')
+  , fs = require('fs')
+  , returnColorizedShift = require(global.config.root_dir + '/lib/ColorizeShift')
+  ;
 
 var date_format = 'YYYY-MM-DD HH:mm:ss';
 
@@ -68,17 +70,21 @@ function handleTimeOffRequests() {
 
                         batchPayload.push(shiftDeleteRequest);
 
-                        var newOpenShiftRequest = {
-                            "method": "post",
-                            "url": "/2/shifts",
-                            "params": {
+                        var params = {
                                 "start_time": shift.start_time,
                                 "end_time": shift.end_time,
                                 "notes": "SHIFT COVERAGE",
                                 "published": true,
                                 "location_id": global.config.locationID
                                                      .makeup_and_extra_shifts,
-                            }
+                            };
+
+                        params = returnColorizedShift(params, shift.start_time, true);
+
+                        var newOpenShiftRequest = {
+                            "method": "post",
+                            "url": "/2/shifts",
+                            "params": params
                         };
                         batchPayload.push(newOpenShiftRequest);
                     });

--- a/lib/ColorizeShift.js
+++ b/lib/ColorizeShift.js
@@ -1,6 +1,11 @@
-var moment = require('moment');
-var colors = require('../config').shiftColors;
-var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+var moment = require('moment')
+  , shiftColors = require('../config').shiftColors;
+
+var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ'
+  , red  = 'D61F27'
+  , lightGray = 'cccccc'
+  , darkGray = '5e5e5e'
+  ;
 
 /**
  * If start_time is undefined, this function will search the
@@ -8,8 +13,14 @@ var WIWDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
  * we're doing a shift update and therefore not passing in an
  * entire shift, we will check the second parameter.
  */
-module.exports = function(shiftToColorize, startTime) {
-    if (typeof startTime == 'undefined') {
+module.exports = function(shiftToColorize, startTime, isMakeup) {
+    var gray = (isMakeup) ? lightGray : darkGray
+      , colors = {
+        red : red,
+        gray : gray
+      };
+
+    if (typeof startTime == 'undefined' || startTime == null) {
         startTime = moment(shiftToColorize.start_time, WIWDateFormat);
     } else {
         startTime = moment(startTime, WIWDateFormat);
@@ -18,8 +29,8 @@ module.exports = function(shiftToColorize, startTime) {
     var day = startTime.format('ddd');
     var time = startTime.format('ha');
 
-    if (colors[day] && colors[day][time]) {
-        shiftToColorize.color = colors[day][time];
+    if (shiftColors[day] && shiftColors[day][time]) {
+        shiftToColorize.color = colors[shiftColors[day][time]];
     }
 
     return shiftToColorize;

--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -3,7 +3,7 @@ var express   = require.main.require('express')
   , moment    = require.main.require('moment')
   , sha1      = require.main.require('sha1')
   , stathat   = require(global.config.root_dir + '/lib/stathat')
-  , colorizeShift = require(global.config.root_dir + '/lib/ColorizeShift')
+  , returnColorizedShift = require(global.config.root_dir + '/lib/colorizeShift')
   ;
 
 var router = express.Router()
@@ -191,7 +191,7 @@ router.delete('/shifts', function(req, res) {
                             user_id: 0,
                             notes: ''
                         };
-                        updatedShiftParams = colorizeShift(updatedShiftParams, shift.start_time);
+                        updatedShiftParams = returnColorizedShift(updatedShiftParams, shift.start_time);
                         var reassignShiftToOpenAndRemoveNotesRequest = {
                             "method": 'PUT',
                             "url": "/2/shifts/" + shift.id,
@@ -217,13 +217,15 @@ router.delete('/shifts', function(req, res) {
                 }
             }
             else if (shift.location_id === global.config.locationID.makeup_and_extra_shifts && shiftIDsOfMakeupShiftsToBeDeleted.indexOf(shift.id) != -1) {
+                var params = {
+                    user_id : 0
+                };
+                param = returnColorizedShift(params, shift.start_time, true);
                 var openShiftRequest = {
                     method : 'PUT',
                     url : '/2/shifts/' + shift.id,
-                    params : {
-                        user_id: 0
-                    }
-                }
+                    params : params
+                };
                 batchPayload.push(openShiftRequest);
 
                 var formattedStartTime = moment(shift.start_time, wiwDateFormat).tz('America/New_York').format(chooseMakeupShiftToCancelPageStartDateFormat);


### PR DESCRIPTION
#### What's this PR do?
Makeup shifts created by timeoff requests were not deliberately being colorized. This colorizes them to be light gray if they're non-urgent, and red if they are during urgent times. 

This also changes how `colorizeShift` works to support makeup shifts being colorized a different way. 

#### How should this be manually tested?
Tested by confirming that makeup shifts. 