### PR TITLE
add merge makeup shift functionality, refactor, merge task

### DIFF
--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -16,56 +16,91 @@ function mergeOpenShifts() {
         include_allopen: true,
         start: '-1 day',
         end: '+7 days',
-        location_id: global.config.locationID.regular_shifts
+        location_id: [ global.config.locationID.regular_shifts, global.config.locationID.makeup_and_extra_shifts ]
     };
 
     WhenIWork.get('shifts', query, function (data) {
-        var openShifts = {};
+        var openRegShifts = {}
+          , openMakShifts = {}
+          , shift
+          , batchPayload = []
+          ;
 
         for (var i in data.shifts) {
-            if (data.shifts[i].is_open) {
-                var shift = data.shifts[i];
-
-                if (typeof openShifts[shift.start_time] == 'undefined') {
-                    openShifts[shift.start_time] = [];
+            shift = data.shifts[i];
+            if (shift.is_open && shift.location_id == global.config.locationID.regular_shifts) {
+                if (typeof openRegShifts[shift.start_time] == 'undefined') {
+                    openRegShifts[shift.start_time] = [];
                 }
-
-                openShifts[shift.start_time].push(shift);
+                openRegShifts[shift.start_time].push(shift);
+            }
+            else if (shift.is_open && shift.location_id == global.config.locationID.makeup_and_extra_shifts) {
+                if (typeof openMakShifts[shift.start_time] == 'undefined') {
+                    openMakShifts[shift.start_time] = [];
+                }
+                openMakShifts[shift.start_time].push(shift);
             }
         }
 
-        for (var i in openShifts) {
-            if (openShifts[i].length > 1) {
-                var shift = openShifts[i];
-                var max = -1;
-                var instances = 0;
-                var remainingShiftUpdated = false;
-
-                for (var j in shift) {
-                    if (shift[j].instances == undefined || shift[j].instances == 0) {
-                        instances += 1;
-                    } else {
-                        instances += shift[j].instances;
-
-                        if (shift[j].instances > max) {
-                            max = shift[j].instances;
-                        }
-                    }
-                }
-
-                for (var j in shift) {
-                    if (shift[j].instances !== undefined && shift[j].instances == max && !remainingShiftUpdated) {
-                        var update = {instances: instances};
-                        update = returnColorizedShift(update, shift[j].start_time);
-
-                        WhenIWork.update('shifts/'+shift[j].id, update);
-
-                        remainingShiftUpdated = true;
-                    } else {
-                        WhenIWork.delete('shifts/'+shift[j].id);
-                    }
-                }
-            }
+        for (key in openRegShifts) {
+            batchPayload = makeBatchPayloadRequestsToMergeOpenShifts(openRegShifts[key], batchPayload);
         }
+
+        for (key in openMakShifts) {
+            batchPayload = makeBatchPayloadRequestsToMergeOpenShifts(openMakShifts[key], batchPayload);
+        }
+
+        WhenIWork.post('batch', batchPayload, function(response) {
+            console.log('Response from merge shift batch payload request: ', batchPayload);
+        })
     });
 }
+
+function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, batchPayload) {
+    if (arrayOfShiftsForSameTimeInt && arrayOfShiftsForSameTimeInt.length > 1) {
+        var max = -1
+          , instances = 0
+          , remainingShiftUpdated = false
+          ;
+
+        for (var j in arrayOfShiftsForSameTimeInt) {
+            if (arrayOfShiftsForSameTimeInt[j].instances == undefined || arrayOfShiftsForSameTimeInt[j].instances == 0) {
+                instances += 1;
+            } else {
+                instances += arrayOfShiftsForSameTimeInt[j].instances;
+
+                if (arrayOfShiftsForSameTimeInt[j].instances > max) {
+                    max = arrayOfShiftsForSameTimeInt[j].instances;
+                }
+            }
+        }
+
+        for (var j in arrayOfShiftsForSameTimeInt) {
+            if (arrayOfShiftsForSameTimeInt[j].instances !== undefined && arrayOfShiftsForSameTimeInt[j].instances == max && !remainingShiftUpdated) {
+                var update = {instances: instances};
+                var isMakeupShift = arrayOfShiftsForSameTimeInt[j].location_id === global.config.locationID.makeup_and_extra_shifts;
+                update = returnColorizedShift(update, arrayOfShiftsForSameTimeInt[j].start_time, isMakeupShift);
+
+
+                var shiftUpdateRequest = {
+                    'method': 'PUT',
+                    'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
+                    'params': update
+                }
+
+                batchPayload.push(shiftUpdateRequest);
+                remainingShiftUpdated = true;
+            } else {
+                var shiftDeleteRequest = {
+                    'method': 'delete',
+                    'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
+                    'params': {}
+                }
+                batchPayload.push(shiftDeleteRequest);
+            }
+        }
+    }
+    return batchPayload;
+}
+
+module.exports = mergeOpenShifts;

--- a/tasks/merge.js
+++ b/tasks/merge.js
@@ -1,0 +1,8 @@
+var WhenIWork = require('wheniwork-unofficial');
+var api = new WhenIWork(global.config.wheniwork.api_key, global.config.wheniwork.username, global.config.wheniwork.password);
+
+var merge = require('../jobs/scheduling/MergeOpenShifts');
+
+module.exports.merge = function() {
+    merge();
+}


### PR DESCRIPTION
#### What's this PR do?
Previously, makeup shifts weren't getting merged. (There were many makeup shifts appearing for same time as opposed to one makeup shift with many instances.)

This PR updates the job so that they are merged together, and colorizes them properly. 

This also adds a task so we can run the merge ourselves. 

#### How should this be manually tested?
Tested in the `test` and `test2` environments, then tested again by running against production via the task. Works. 