### PR TITLE
fix delete shift, not loading if no weekly shifts to delete

### DIFF
--- a/www/routes/scheduling/index.js
+++ b/www/routes/scheduling/index.js
@@ -31,6 +31,7 @@ router.get('/shifts', function(req, res) {
     api.get('users', function (dataResponse) {
         var users = dataResponse.users
           , user
+          , templateData
           ;
 
         for (var i = 0; i < users.length; i++) {
@@ -51,7 +52,17 @@ router.get('/shifts', function(req, res) {
                     var url = scheduleShiftsURL + 'email=' + encodeURIComponent(email) + '&token=' + req.query.token;
                     if (!response.shifts || !response.shifts.length) {
                         var error = "You don't seem to have booked any shifts to delete! If this message is sent in error, contact scheduling@crisistextline.org";
-                        res.render('scheduling/chooseShiftToCancel', { error: error , url: url });
+                        templateData = {
+                            regularShifts: [],
+                            makeupShifts: [],
+                            userID: userID,
+                            email: email,
+                            token: req.query.token,
+                            userName: userName,
+                            error: error,
+                            url: url
+                        };
+                        res.render('scheduling/chooseShiftToCancel', templateData);
                         return;
                     }
                     var shifts = response.shifts
@@ -121,7 +132,7 @@ router.get('/shifts', function(req, res) {
                         shift.end_time = moment(shift.end_time, wiwDateFormat).tz('America/New_York').format(chooseMakeupShiftToCancelPageEndDateFormat);
                     });
 
-                    var templateData = {
+                    templateData = {
                         regularShifts: regularShifts,
                         makeupShifts: makeupShifts,
                         userID: userID,
@@ -132,6 +143,7 @@ router.get('/shifts', function(req, res) {
 
                     // Then, display them in the jade template.
                     res.render('scheduling/chooseShiftToCancel', templateData);
+                    return;
                 })
                 break;
             }

--- a/www/views/scheduling/chooseShiftToCancel.jade
+++ b/www/views/scheduling/chooseShiftToCancel.jade
@@ -5,21 +5,23 @@ block content
         h3=error
         | #[a(href="#{url}") schedule another shift]
     - }
-    - else if (regularShifts && regularShifts.length > 0) {
+    - else if((makeupShifts && makeupShifts.length > 0) || (regularShifts && regularShifts.length > 0)) {
         h2=userName + "'s shifts"
         h3 delete individual shifts - choose up to two shifts to delete at a time
-        h4 Weekly shifts
         form(name="cancel-form")
             input(type="hidden", name="email", value=email)
             input(type="hidden", name="userID", value=userID)
             input(type="hidden", name="token", value=token)
             input(type="hidden", name="userName", value=userName)
-            each shift in regularShifts
-                - var parentShiftID = JSON.parse(shift.notes).parent_shift
-                - var title = shift.start_time + ' to ' + shift.end_time
-                div.input
-                    input(type="checkbox", name='regShift' + parentShiftID)
-                    span.label=title
+            - if (regularShifts && regularShifts.length > 0) {
+                h4 Weekly shifts
+                each shift in regularShifts
+                    - var parentShiftID = JSON.parse(shift.notes).parent_shift
+                    - var title = shift.start_time + ' to ' + shift.end_time
+                    div.input
+                        input(type="checkbox", name='regShift' + parentShiftID)
+                        span.label=title
+            - }
             - if (makeupShifts && makeupShifts.length > 0) {
                 h4 One-time (or makeup) shifts
                 each shift in makeupShifts
@@ -31,4 +33,11 @@ block content
             - }
             div.actions
                 input(type="submit", id="delete-shifts")
+    - }
+    - else {
+        h2 you have not scheduled any shifts yet!
+        form(action="#{url}", method="get")
+            input(type="hidden", name="email", value=email)
+            input(type="hidden", name="token", value=token)
+            input(type="submit", value="Schedule a shift")
     - }


### PR DESCRIPTION
#### What's this PR do?
Previously, when a user had only booked one-time (makeup) shifts, and not regular (weekly) shifts, their shift deletion screen didn't load because Jade would error out. 

This fixes that. 

(We also add a small `return` statement in `/www/routes/scheduling/index.js` to avoid the potential "can't set headers after they are sent" error. 

#### How should this be manually tested?
Tested by booking shifts in prod on WhenIWork, and then deleting them by running Elmer locally. 

#### What are the relevant tickets?
Closes https://admin.crisistextline.org/jira/browse/INT-72