### PR TITLE
add support a two-week open shift window

### DIFF
--- a/config.js.default
+++ b/config.js.default
@@ -101,12 +101,6 @@ config.time_interval = {
   // Used to search for requests to be auto-approved.
   months_to_search_for_time_off_requests: 6,
 
-  // Used to search for users in order to notify them via email.
-  days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7,
-
-  // How often we repeat open shifts
-  days_in_interval_to_repeat_open_shifts: 7,
-
   // How many days in advance we show open shifts
   days_of_open_shift_display: 14
 };

--- a/config.js.default
+++ b/config.js.default
@@ -77,6 +77,12 @@ config.time_interval = {
   // runs every five mins.
   time_off_requests_cron_job_string: '0 */5 * * * *',
 
+  // How often do we create new openshifts and merge duplicate openshifts
+  open_shifts: '0 0 */2 * * *', // every two hours
+
+  // How often do we notify users to take more shifts
+  take_more_shifts_cron_job_string: '30 5 18 * * *', // Every day at 6:05:30 pm
+
   // Each recurrence chain is 1 year long.
   max_shifts_in_chain: 52,
 
@@ -98,11 +104,11 @@ config.time_interval = {
   // Used to search for users in order to notify them via email.
   days_to_search_for_new_users_who_have_scheduled_their_first_shift: 7,
 
-  // How often do we create new openshifts and merge duplicate openshifts
-  open_shifts: '0 0 */2 * * *', // every two hours
-
   // How often we repeat open shifts
-  days_in_interval_to_repeat_open_shifts: 7
+  days_in_interval_to_repeat_open_shifts: 7,
+
+  // How many days in advance we show open shifts
+  days_of_open_shift_display: 14
 };
 
 config.mandrill = {

--- a/config.js.default
+++ b/config.js.default
@@ -14,6 +14,32 @@ global.CONSOLE_WITH_TIME = function(){
   console.log('[' + new Date() + ']', message.slice(0, message.length-1));
 };
 
+/**
+  Accepts a string returned from WIW formatted like this:
+  "Wed, 01 Jun 2016, 12:00:00 -500"
+  And converts it to a string with the time zone formatted like this:
+  "Wed, 01 Jun 2016, 12:00:00 -0500"
+
+  So that it's Moment() parseable. Otherwise, Moment() fails to parse it,
+  and it defaults to creating a date based on the current time. Not good.
+  Moment wants this format:
+  "ddd, DD MMM YYYY HH:mm:ss ZZ"
+**/
+global.MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE = function(timestring) {
+  // Wed, 01 Jun 2016 12:00:00
+  var firstPart = timestring.slice(0, 25).trim();
+  // -500
+  var timeZonePart =  timestring.slice(-5).trim();
+  if (moment(firstPart, 'ddd, DD MMM YYYY HH:mm:ss', true).format() === 'Invalid date') {
+    CONSOLE_WITH_TIME('[ERROR] invalid date being parsed with MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE');
+    return false;
+  }
+  if (timeZonePart.length === 4) {
+    timeZonePart = timeZonePart.substr(0, 1) + '0' + timeZonePart.substr(1);
+  }
+  return firstPart + ' ' + timeZonePart;
+};
+
 var config = {};
 
 config.root_dir = __dirname;
@@ -61,7 +87,7 @@ config.time_interval = {
   years_to_recur_shift: 5,
 
   // In looking for newly created shifts to recur, we search 2 weeks from the present.
-  weeks_to_search_for_recurred_shifts: 2,
+  weeks_to_search_for_recurred_shifts: 3,
 
   // While we recur shifts for much longer, they're only published (viewable to the employee) 4 weeks from present.
   weeks_to_publish_recurred_shifts: 4,

--- a/config.js.default
+++ b/config.js.default
@@ -92,7 +92,7 @@ config.time_interval = {
   // Each shift is recurred for 5 years.
   years_to_recur_shift: 5,
 
-  // In looking for newly created shifts to recur, we search 2 weeks from the present.
+  // In looking for newly created shifts to recur, we search 3 weeks from the present.
   weeks_to_search_for_recurred_shifts: 3,
 
   // While we recur shifts for much longer, they're only published (viewable to the employee) 4 weeks from present.
@@ -102,7 +102,7 @@ config.time_interval = {
   months_to_search_for_time_off_requests: 6,
 
   // How many days in advance we show open shifts
-  days_of_open_shift_display: 14
+  days_of_open_shift_display: 15
 };
 
 config.mandrill = {

--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -1,11 +1,10 @@
-
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
 var returnColorizedShift = require('../../lib/ColorizeShift').go;
 
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-new CronJob(global.config.time_interval.open_shifts, function () {
+new CronJob(config.time_interval.open_shifts, function () {
     mergeOpenShifts();
 }, null, true);
 
@@ -15,26 +14,25 @@ function mergeOpenShifts() {
   var query = {
     include_allopen: true,
     start: '-1 day',
-    end: '+7 days',
-    location_id: [ global.config.locationID.regular_shifts, global.config.locationID.makeup_and_extra_shifts ]
+    end: '+' + config.time_interval.days_of_open_shift_display + ' days',
+    location_id: [ config.locationID.regular_shifts, config.locationID.makeup_and_extra_shifts ]
   };
 
   WhenIWork.get('shifts', query, function (data) {
-    var openRegShifts = {}
-      , openMakShifts = {}
-      , shift
-      , batchPayload = []
-      ;
+    var openRegShifts = {};
+    var openMakShifts = {};
+    var shift;
+    var batchPayload = [];
 
     for (var i in data.shifts) {
       shift = data.shifts[i];
-      if (shift.is_open && shift.location_id == global.config.locationID.regular_shifts) {
+      if (shift.is_open && shift.location_id == config.locationID.regular_shifts) {
         if (typeof openRegShifts[shift.start_time] == 'undefined') {
           openRegShifts[shift.start_time] = [];
         }
         openRegShifts[shift.start_time].push(shift);
       }
-      else if (shift.is_open && shift.location_id == global.config.locationID.makeup_and_extra_shifts) {
+      else if (shift.is_open && shift.location_id == config.locationID.makeup_and_extra_shifts) {
         if (typeof openMakShifts[shift.start_time] == 'undefined') {
           openMakShifts[shift.start_time] = [];
         }
@@ -42,29 +40,28 @@ function mergeOpenShifts() {
       }
     }
 
-    for (key in openRegShifts) {
+    for (var key in openRegShifts) {
       batchPayload = makeBatchPayloadRequestsToMergeOpenShifts(openRegShifts[key], batchPayload);
     }
 
-    for (key in openMakShifts) {
+    for (var key in openMakShifts) {
       batchPayload = makeBatchPayloadRequestsToMergeOpenShifts(openMakShifts[key], batchPayload);
     }
 
     WhenIWork.post('batch', batchPayload, function(response) {
       CONSOLE_WITH_TIME('Response from merge shift batch payload request: ', batchPayload);
-    })
+    });
   });
 }
 
 function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, batchPayload) {
   if (arrayOfShiftsForSameTimeInt && arrayOfShiftsForSameTimeInt.length > 1) {
-    var max = -1
-      , instances = 0
-      , remainingShiftUpdated = false
-      ;
+    var max = -1;
+    var instances = 0;
+    var remainingShiftUpdated = false;
 
     for (var j in arrayOfShiftsForSameTimeInt) {
-      if (arrayOfShiftsForSameTimeInt[j].instances == undefined || arrayOfShiftsForSameTimeInt[j].instances == 0) {
+      if (arrayOfShiftsForSameTimeInt[j].instances === undefined || arrayOfShiftsForSameTimeInt[j].instances === 0) {
         instances += 1;
       } else {
         instances += arrayOfShiftsForSameTimeInt[j].instances;
@@ -78,7 +75,7 @@ function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, 
     for (var j in arrayOfShiftsForSameTimeInt) {
       if (arrayOfShiftsForSameTimeInt[j].instances !== undefined && arrayOfShiftsForSameTimeInt[j].instances == max && !remainingShiftUpdated) {
         var update = {instances: instances};
-        var isMakeupShift = arrayOfShiftsForSameTimeInt[j].location_id === global.config.locationID.makeup_and_extra_shifts;
+        var isMakeupShift = arrayOfShiftsForSameTimeInt[j].location_id === config.locationID.makeup_and_extra_shifts;
         update = returnColorizedShift(update, arrayOfShiftsForSameTimeInt[j].start_time, isMakeupShift);
 
 
@@ -86,7 +83,7 @@ function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, 
           'method': 'PUT',
           'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
           'params': update
-        }
+        };
 
         batchPayload.push(shiftUpdateRequest);
         remainingShiftUpdated = true;
@@ -95,7 +92,7 @@ function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, 
           'method': 'delete',
           'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
           'params': {}
-        }
+        };
         batchPayload.push(shiftDeleteRequest);
       }
     }

--- a/jobs/scheduling/NotifyFirstShift.js
+++ b/jobs/scheduling/NotifyFirstShift.js
@@ -4,11 +4,11 @@ var moment = require('moment');
 var fs = require('fs');
 
 var mandrill = require('mandrill-api/mandrill');
-var mandrill_client = new mandrill.Mandrill(global.config.mandrill.api_key);
+var mandrill_client = new mandrill.Mandrill(config.mandrill.api_key);
 
 var date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-new CronJob(global.config.time_interval.notify_first_shift_cron_job_string, function () {
+new CronJob(config.time_interval.notify_first_shift_cron_job_string, function () {
   checkNewShifts();
 }, null, true);
 
@@ -18,7 +18,7 @@ function checkNewShifts() {
   // TODO: Re-enable this.
   return;
 
-  WhenIWork.get('users', {location_id: global.config.locationID.new_graduate}, function (users) {
+  WhenIWork.get('users', {location_id: config.locationID.new_graduate}, function (users) {
     var now = moment();
     var template = fs.readFileSync('./email_templates/shift_welcome.txt', {encoding: 'utf-8'});
 
@@ -26,11 +26,11 @@ function checkNewShifts() {
       var u = users.users[i];
       var created = moment(u.created_at, date_format);
 
-      if (u.notes.indexOf('first_shift_notified') < 0 && now.diff(created, 'days') < global.config.days_to_search_for_new_users_who_have_scheduled_their_first_shift) {
+      if (u.notes.indexOf('first_shift_notified') < 0 && now.diff(created, 'days') < config.days_of_open_shift_display) {
         var q = {
           user_id: u.id,
           start: moment().format(date_format),
-          end: moment().add(global.config.days_to_search_for_new_users_who_have_scheduled_their_first_shift, 'days').format(date_format)
+          end: moment().add(config.days_of_open_shift_display, 'days').format(date_format)
         };
 
         WhenIWork.get('shifts', q, function (shifts) {
@@ -41,7 +41,7 @@ function checkNewShifts() {
             var created = moment(s.created_at, date_format);
 
             if (now.diff(created, 'minutes') <= interval && !sent) {
-              var sent = true;
+              sent = true;
               var shift_start = moment(s.start_time, date_format).format('MMM D, YYYY HH:mm');
 
               var content = template.replace('%name', shifts.users[0].first_name).replace('%date', shift_start);

--- a/jobs/scheduling/NotifyMoreShifts.js
+++ b/jobs/scheduling/NotifyMoreShifts.js
@@ -1,16 +1,16 @@
 var CronJob = require('cron').CronJob;
 var WhenIWork = require('./base');
 var fs = require('fs');
-var stathat = require(global.config.root_dir + '/lib/stathat');
+var stathat = require(config.root_dir + '/lib/stathat');
 
-new CronJob('30 5 18 * * *', function () {
+new CronJob(config.time_interval.take_more_shifts_cron_job_string, function () {
   notifyMoreShifts();
 });
 
 function notifyMoreShifts() {
   var query = {
-    location_id: global.config.locationID.regular_shifts,
-    end: '+7 days'
+    location_id: config.locationID.regular_shifts,
+    end: '+' + config.time_interval.days_of_open_shift_display + ' days'
   };
 
   WhenIWork.get('shifts', query, function (data) {
@@ -58,7 +58,7 @@ function processUsers(users) {
     // Now we're going to notify these people once. So the logic is more complicated.
     if (only_two.length > 0) {
       var req = {
-        location_id: global.config.locationID.regular_shifts
+        location_id: config.locationID.regular_shifts
       };
 
       WhenIWork.get('users', req, function (data) {

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -18,6 +18,7 @@ function runJob() {
 // run it once on boot
 runJob();
 
+// Recurs open shifts one and two weeks in the future.
 function recurOpenShifts(now) {
   if (now.hours() % 2 == 1) {
     CONSOLE_WITH_TIME('running at an odd hour. abort.');
@@ -28,64 +29,22 @@ function recurOpenShifts(now) {
     // Because we're making async calls in a loop, we pass targetTime through callback
     // so that it's defined locally for each scope.
     var targetTime = now.clone().add(i * -2, 'hours');
-    findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTime, function(extraOpenShiftsToDelete, correctNumberOfShiftsToSet, targetTime) {
-      var batchPayload = [];
-
-      // If we don't need to add any new open shifts, we return.
-      if (correctNumberOfShiftsToSet === 0) {
-        CONSOLE_WITH_TIME('No open shifts need to be added for time: ', targetTime.toString());
-        return;
-      }
-      // If we need to add open shifts
-      else if (correctNumberOfShiftsToSet > 0) {
-        var newOpenShiftParams = {
-          start_time: targetTime.clone().minute(0).second(0).add(1, 'week').format(WIWDateFormat),
-          end_time: targetTime.clone().minute(0).second(0).add(2, 'hour').add(1, 'week').format(WIWDateFormat),
-          location_id: global.config.locationID.regular_shifts,
-          instances: correctNumberOfShiftsToSet,
-          published: true
-        };
-        newOpenShiftParams = colorizeShift(newOpenShiftParams);
-
-        var newOpenShiftRequest = {
-          method: "post",
-          url: "/2/shifts",
-          params: newOpenShiftParams
-        };
-        batchPayload.push(newOpenShiftRequest);
-      }
-      /**
-        Batch delete the invalid open shifts in two cases: 1) correctNumberOfShiftsToSet > 0; we need to add open shifts
-        and 2) correctNumberOfShiftsToSet < 0; the number of occupied shifts is currently greater than the total number
-        of open shifts for that block. In BOTH cases, we need to delete all old open shifts.
-      **/
-
-      extraOpenShiftsToDelete.forEach(function(shiftID) {
-        var shiftDeleteRequest = {
-            method: "delete",
-            url: "/2/shifts/" + shiftID,
-            params: {}
-        };
-        batchPayload.push(shiftDeleteRequest);
-      });
-
-      if (correctNumberOfShiftsToSet < 0) { correctNumberOfShiftsToSet = 'no'; }
-      CONSOLE_WITH_TIME('Adding ', correctNumberOfShiftsToSet, ' open shifts to the time: ', targetTime.toString(), '. Deleting incorrect count of open shifts--their shift IDs: ', extraOpenShiftsToDelete);
-      WhenIWork.post('batch', batchPayload);
-    })
+    findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTime, 1, incrementFutureOpenShiftsUpOrDown);
+    findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTime, 2, incrementFutureOpenShiftsUpOrDown);
   }
 }
+
 /**
-  Checks if open shifts are already present a week from the targetTime
+  Checks if open shifts are already present weeksFromNowToCheck number of weeks from the targetTime
   Callback params: callback(extraOpenShiftsToDelete, correctNumberOfShiftsToSet, targetTimeMomentObj);
 **/
-function findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTimeMomentObj, callback) {
-  var extraOpenShiftsToDelete = []
-    , countOfOccupiedShifts = 0
-    , countOfOpenShifts = 0
-    , targetTimeMomentObj = targetTimeMomentObj
-    , shift
-    ;
+function findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTimeMomentObj, weeksFromNowToCheck, callback) {
+  var extraOpenShiftsToDelete = [];
+  var countOfOccupiedShifts = 0;
+  var countOfOpenShifts = 0;
+  var shift;
+
+  targetTimeMomentObj = targetTimeMomentObj;
   /*
     Querying for shifts starting at 8pm produces weird, buggy behavior from the WIW API.
     Guess: 8pm is the dividing line between GMT days. So if we query for shifts starting a
@@ -93,8 +52,8 @@ function findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTimeMomentObj, c
     is precisely on the hour.
   */
   var filter = {
-    start: targetTimeMomentObj.clone().add(1, 'week').format(shiftQueryDateFormat),
-    end: targetTimeMomentObj.clone().add(1, 'minute').add(1, 'week').format(shiftQueryDateFormat),
+    start: targetTimeMomentObj.clone().add(weeksFromNowToCheck, 'week').format(shiftQueryDateFormat),
+    end: targetTimeMomentObj.clone().add(1, 'minute').add(weeksFromNowToCheck, 'week').format(shiftQueryDateFormat),
     include_allopen: true,
     location_id: global.config.locationID.regular_shifts
   };
@@ -117,10 +76,60 @@ function findExtraOpenShiftsToDeleteAndOccupiedShiftCount(targetTimeMomentObj, c
     }
 
     var correctNumberOfShiftsToSet = returnMaxOpenShiftCountForTime(targetTimeMomentObj.clone()) - countOfOccupiedShifts;
-    CONSOLE_WITH_TIME('Found ', countOfOpenShifts, ' open shifts, ', countOfOccupiedShifts, ' occupied shifts found for a time where we expect ', returnMaxOpenShiftCountForTime(targetTimeMomentObj.clone()), ' open shifts. Time: ', targetTimeMomentObj.toString());
-    callback(extraOpenShiftsToDelete, correctNumberOfShiftsToSet, targetTimeMomentObj);
+    CONSOLE_WITH_TIME('Found ', countOfOpenShifts, ' open shifts, ', countOfOccupiedShifts, ' occupied shifts found for a time ', weeksFromNowToCheck, 'weeks from now where we expect ', returnMaxOpenShiftCountForTime(targetTimeMomentObj.clone()), ' open shifts. Time: ', targetTimeMomentObj.toString());
+    callback(extraOpenShiftsToDelete, correctNumberOfShiftsToSet, weeksFromNowToCheck, targetTimeMomentObj);
     return;
   });
+}
+
+/**
+  Based on the shift information passed to this function by findExtraOpenShiftsToDeleteAndOccupiedShiftCount,
+  this function adds open shifts or delete open shifts to match the proper number.
+**/
+function incrementFutureOpenShiftsUpOrDown(extraOpenShiftsToDelete, correctNumberOfShiftsToSet, weeksFromNowToCheck, targetTime) {
+  var batchPayload = [];
+
+  // If we don't need to add any new open shifts, we return.
+  if (correctNumberOfShiftsToSet === 0) {
+    CONSOLE_WITH_TIME('No open shifts need to be added for time: ', targetTime.toString());
+    return;
+  }
+  // If we need to add open shifts
+  else if (correctNumberOfShiftsToSet > 0) {
+    var newOpenShiftParams = {
+      start_time: targetTime.clone().minute(0).second(0).add(weeksFromNowToCheck, 'weeks').format(WIWDateFormat),
+      end_time: targetTime.clone().minute(0).second(0).add(2, 'hour').add(weeksFromNowToCheck, 'weeks').format(WIWDateFormat),
+      location_id: global.config.locationID.regular_shifts,
+      instances: correctNumberOfShiftsToSet,
+      published: true
+    };
+    newOpenShiftParams = colorizeShift(newOpenShiftParams);
+
+    var newOpenShiftRequest = {
+      method: "post",
+      url: "/2/shifts",
+      params: newOpenShiftParams
+    };
+    batchPayload.push(newOpenShiftRequest);
+  }
+
+  /**
+    Batch delete the invalid open shifts in two cases: 1) correctNumberOfShiftsToSet > 0; we need to add open shifts
+    and 2) correctNumberOfShiftsToSet < 0; the number of occupied shifts is currently greater than the total number
+    of open shifts for that block. In BOTH cases, we need to delete all old open shifts.
+  **/
+  extraOpenShiftsToDelete.forEach(function(shiftID) {
+    var shiftDeleteRequest = {
+      method: "delete",
+      url: "/2/shifts/" + shiftID,
+      params: {}
+    };
+    batchPayload.push(shiftDeleteRequest);
+  });
+
+  if (correctNumberOfShiftsToSet < 0) { correctNumberOfShiftsToSet = 'no'; }
+  CONSOLE_WITH_TIME('Adding ', correctNumberOfShiftsToSet, ' open shifts to the time: ', targetTime.toString(), ' . Deleting incorrect count of open shifts--their shift IDs: ', extraOpenShiftsToDelete);
+  WhenIWork.post('batch', batchPayload);
 }
 
 function returnMaxOpenShiftCountForTime(targetTimeMomentObj) {
@@ -134,5 +143,6 @@ module.exports = {
   recurOpenShifts: recurOpenShifts,
   returnMaxOpenShiftCountForTime: returnMaxOpenShiftCountForTime,
   findExtraOpenShiftsToDeleteAndOccupiedShiftCount: findExtraOpenShiftsToDeleteAndOccupiedShiftCount,
+  incrementFutureOpenShiftsUpOrDown: incrementFutureOpenShiftsUpOrDown,
   cronJob: cronJob
 };

--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -4,9 +4,9 @@ var moment = require('moment-timezone');
 var fs = require('fs');
 var async = require('async');
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
-var stathat = require(global.config.root_dir + '/lib/stathat');
+var stathat = require(config.root_dir + '/lib/stathat');
 
-new CronJob(global.config.time_interval.recur_and_publish_shifts_cron_job_string, function () {
+new CronJob(config.time_interval.recur_and_publish_shifts_cron_job_string, function () {
   recurNewlyCreatedShifts();
 }, null, true);
 
@@ -17,10 +17,10 @@ function recurNewlyCreatedShifts() {
   // Only searching for newly created shifts one day prior and two weeks out since counselors
   // only can create a new shift in the next week.
   var startDateToRetrieveShifts = moment().add(-1, 'days').format('YYYY-MM-DD HH:mm:ss');
-  var endDateToRetrieveShifts = moment().add(global.config.time_interval.weeks_to_search_for_recurred_shifts, 'weeks').format('YYYY-MM-DD HH:mm:ss');
+  var endDateToRetrieveShifts = moment().add(config.time_interval.weeks_to_search_for_recurred_shifts, 'weeks').format('YYYY-MM-DD HH:mm:ss');
   var postData = {
                     "include_open": false,
-                    "location_id": global.config.locationID.regular_shifts,
+                    "location_id": config.locationID.regular_shifts,
                     "start": startDateToRetrieveShifts,
                     "end": endDateToRetrieveShifts
                   };
@@ -48,7 +48,7 @@ function recurNewlyCreatedShifts() {
     **/
     newShifts.forEach(function(shift) {
       shift.notes = '{"original_owner":' + shift.user_id + ', "parent_shift":' + shift.id + '}';
-      var endDate = moment(shift.start_time, wiw_date_format).add(global.config.time_interval.max_shifts_in_chain - 1, 'weeks').format('L');
+      var endDate = moment(shift.start_time, wiw_date_format).add(config.time_interval.max_shifts_in_chain - 1, 'weeks').format('L');
 
       /**
         WhenIWork uses the end of the shift to determine which day it falls on, therefore shifts ending at midnight
@@ -58,7 +58,7 @@ function recurNewlyCreatedShifts() {
         (Tested with shifts which recur between 8-10pm.) Hence, we're also extending the end_time for that case.
       **/
       if (moment(shift.end_time, wiw_date_format).format('H') === '0' || moment(shift.end_time, wiw_date_format).format('H') === '22') {
-          endDate = moment(endDate, 'L').add(global.config.time_interval.chain_buffer_days, 'days').format('L');
+          endDate = moment(endDate, 'L').add(config.time_interval.chain_buffer_days, 'days').format('L');
       }
 
       shift.chain = {"week":"1","until":endDate};
@@ -77,37 +77,36 @@ function recurNewlyCreatedShifts() {
           all the recurring shifts), we are giving each shift a `parent_shift` property in the notes
           section. This property points to the original shift created by the user.
       **/
-      for (var i = 0; i < global.config.time_interval.years_to_recur_shift - 1; i++) {
-          var newShift = {
-            "method": "post",
-            "url": "/2/shifts",
-            "params": {
-              "start_time": moment(workingShift.start_time, wiw_date_format).add(global.config.time_interval.max_shifts_in_chain, 'weeks').format('ddd, DD MMM YYYY HH:mm:ss ZZ'),
-              "end_time": moment(workingShift.end_time, wiw_date_format).add(global.config.time_interval.max_shifts_in_chain, 'weeks').format('ddd, DD MMM YYYY HH:mm:ss ZZ'),
-              "notes": workingShift.notes,
-              "acknowledged": workingShift.acknowledged,
-              "chain": {"week": "1", "until": moment(workingShift.chain.until, wiw_date_format).add(global.config.time_interval.max_shifts_in_chain, 'weeks').format('L')},
-              "location_id": workingShift.location_id,
-              "user_id": workingShift.user_id
-            }
-          };
-
-          batchPostRequestBody.push(newShift);
-          workingShift = newShift.params;
+      for (var i = 0; i < config.time_interval.years_to_recur_shift - 1; i++) {
+        var newShift = {
+          "method": "post",
+          "url": "/2/shifts",
+          "params": {
+            "start_time": moment(workingShift.start_time, wiw_date_format).add(config.time_interval.max_shifts_in_chain, 'weeks').format('ddd, DD MMM YYYY HH:mm:ss ZZ'),
+            "end_time": moment(workingShift.end_time, wiw_date_format).add(config.time_interval.max_shifts_in_chain, 'weeks').format('ddd, DD MMM YYYY HH:mm:ss ZZ'),
+            "notes": workingShift.notes,
+            "acknowledged": workingShift.acknowledged,
+            "chain": {"week": "1", "until": moment(workingShift.chain.until, wiw_date_format).add(config.time_interval.max_shifts_in_chain, 'weeks').format('L')},
+            "location_id": workingShift.location_id,
+            "user_id": workingShift.user_id
+          }
+        };
+        batchPostRequestBody.push(newShift);
+        workingShift = newShift.params;
       }
-  });
+    });
 
-  WhenIWork.post('batch', batchPostRequestBody, function(response) {
+    WhenIWork.post('batch', batchPostRequestBody, function(response) {
       // After batch of shifts is created, we want to publish all shifts. (Note that passing in the `published` param
       // in the requests that are batched doesn't actually publish them; we need to make a separate request to another route.)
 
       var startDateToRetrieveUnpublishedShifts = moment().add(-12, 'hours').format('YYYY-MM-DD HH:mm:ss');
       var endDateToRetrieveUnpublishedShifts = moment().add(12, 'hours').format('YYYY-MM-DD HH:mm:ss');
       var requestTaskArray = [];
-      for (var i = 0; i < global.config.time_interval.weeks_to_publish_recurred_shifts * 7; i++) {
+      for (var i = 0; i < config.time_interval.weeks_to_publish_recurred_shifts * 7; i++) {
         var firstTask = function(callback) {
           var unpublishedShiftIDs = [];
-          var callback = callback;
+          callback = callback;
 
           /**
             Note that we can’t query exclusively for unpublished shifts, we can only
@@ -115,7 +114,7 @@ function recurNewlyCreatedShifts() {
           **/
           var postData = {
             "include_open": false,
-            "location_id": global.config.locationID.regular_shifts,
+            "location_id": config.locationID.regular_shifts,
             "start": startDateToRetrieveUnpublishedShifts,
             "end": endDateToRetrieveUnpublishedShifts,
             "unpublished": true
@@ -136,18 +135,18 @@ function recurNewlyCreatedShifts() {
 
             callback(null, startDateToRetrieveUnpublishedShifts, endDateToRetrieveUnpublishedShifts, unpublishedShiftIDs);
           });
-        }
+        };
 
         var task = function(startDate, endDate, unpublishedShiftIDs, callback) {
-          var unpublishedShiftIDs = unpublishedShiftIDs;
-          var callback = callback;
+          unpublishedShiftIDs = unpublishedShiftIDs;
+          callback = callback;
 
           startDate = moment(startDate).add(1, 'days').format('YYYY-MM-DD HH:mm:ss');
           endDate = moment(endDate).add(1, 'days').format('YYYY-MM-DD HH:mm:ss');
 
           var postData = {
             "include_open": false,
-            "location_id": global.config.locationID.regular_shifts,
+            "location_id": config.locationID.regular_shifts,
             "start": startDate,
             "end": endDate,
             "unpublished": true
@@ -167,7 +166,7 @@ function recurNewlyCreatedShifts() {
 
             callback(null, startDate, endDate, unpublishedShiftIDs);
           });
-        }
+        };
 
         if (i === 0) {
           requestTaskArray.push(firstTask);
@@ -180,10 +179,10 @@ function recurNewlyCreatedShifts() {
       async.waterfall(requestTaskArray, function(err, startDate, endDate, unpublishedShiftIDs) {
         var publishPayload = {
           'ids': unpublishedShiftIDs
-        }
+        };
 
         WhenIWork.post('shifts/publish/', publishPayload);
-      })
+      });
     });
   });
 }

--- a/tasks/schedule.js
+++ b/tasks/schedule.js
@@ -19,8 +19,8 @@ module.exports.dumpSchedules = function () {
     // Loop through each shift and put them into an object
     // indexed by user id. Ex:
     // { 123: [MomentObject, MomentObject, MomentObject] }
-    for (var i in data['shifts']) {
-      shift = data['shifts'][i];
+    for (var i in data.shifts) {
+      shift = data.shifts[i];
 
       // Create the entry in the object if no exist
       if (typeof user_shifts[shift.user_id] == 'undefined') {
@@ -33,8 +33,8 @@ module.exports.dumpSchedules = function () {
     // Now we need to get the email addresses
     api.get('users', function (data) {
       var user;
-      for (var i in data['users']) {
-        user = data['users'][i];
+      for (var i in data.users) {
+        user = data.users[i];
 
         if (typeof user_shifts[user.id] !== 'undefined') {
           // Switch to email-indexed array
@@ -56,7 +56,7 @@ module.exports.dumpSchedules = function () {
         }
 
         // print the shit
-        CONSOLE_WITH_TIME(line);
+        console.log(line);
       }
     });
   });

--- a/test/loginusercreation.js
+++ b/test/loginusercreation.js
@@ -30,7 +30,7 @@ describe('Login and user creation', function () {
   });
 
   describe('checkUser function', function() {
-    
+
     it('Doesn\'t create a user that already exists', function() {
       checkUser2('amudantest@test.com', 'Amudan', 'Test', function(user) {
         assert.equal(user.email, 'amudantest@test.com');

--- a/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
+++ b/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
@@ -1,26 +1,22 @@
+var helpers = require(config.root_dir + '/www/scheduling/helpers');
+var moment = require('moment');
+var returnColorizedShift = require(config.root_dir + '/lib/ColorizeShift').go;
 
-var helpers = require(global.config.root_dir + '/www/scheduling/helpers')
-  , moment = require('moment')
-  , returnColorizedShift = require(global.config.root_dir + '/lib/ColorizeShift').go
-  ;
-
-var wiwDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ'
-  , chooseRegShiftToCancelPageStartDateFormat = 'dddd h:mm a' // Wednesday 4:00 p
-  , chooseRegShiftToCancelPageEndDateFormat = 'h:mm a z' // 6:00 pm ES
-  , chooseMakeupShiftToCancelPageStartDateFormat = 'dddd, MMM Do YYYY - h:mm a' // Wednesday, Mar 30th 2016 - 4:00 p
-  , chooseMakeupShiftToCancelPageEndDateFormat = 'h:mm a z' // 6:00 pm ES
-  , scheduleShiftsURL = '/scheduling/login?'
-  ;
+var wiwDateFormat = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+var chooseRegShiftToCancelPageStartDateFormat = 'dddd h:mm a'; // Wednesday 4:00 p
+var chooseRegShiftToCancelPageEndDateFormat = 'h:mm a z'; // 6:00 pm ES
+var chooseMakeupShiftToCancelPageStartDateFormat = 'dddd, MMM Do YYYY - h:mm a'; // Wednesday, Mar 30th 2016 - 4:00 p
+var chooseMakeupShiftToCancelPageEndDateFormat = 'h:mm a z'; // 6:00 pm ES
+var scheduleShiftsURL = '/scheduling/login?';
 
 function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
   if (!helpers.validate(req.query.email, req.query.token)) {
     res.status(403).send('Access denied.');
   }
 
-  var parentShiftIDsOfRegularShiftsToBeDeleted = []
-    , shiftIDsOfMakeupShiftsToBeDeleted = []
-    , key
-    ;
+  var parentShiftIDsOfRegularShiftsToBeDeleted = [];
+  var shiftIDsOfMakeupShiftsToBeDeleted = [];
+  var key;
 
   for (key in req.query) {
     if (key.substr(0, 8) === 'regShift' && req.query[key] === 'on') {
@@ -36,18 +32,17 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
     start: '-1 day',
     end: '+50 years',
     unpublished: true,
-    location_id: [ global.config.locationID.regular_shifts, global.config.locationID.makeup_and_extra_shifts ]
+    location_id: [ config.locationID.regular_shifts, config.locationID.makeup_and_extra_shifts ]
   };
 
   whenIWorkAPI.get('shifts', query, function (data) {
-    var parentShiftID
-      , shift
-      , batchPayload = []
-      , deletedShiftInformation = {regShifts : {}, makShifts : {}}
-      ;
+    var parentShiftID;
+    var shift;
+    var batchPayload = [];
+    var deletedShiftInformation = {regShifts : {}, makShifts : {}};
 
     data.shifts.forEach(function(shift) {
-        if (shift.location_id === global.config.locationID.regular_shifts) {
+        if (shift.location_id === config.locationID.regular_shifts) {
           try {
             parentShiftID = JSON.parse(shift.notes).parent_shift;
           }
@@ -57,9 +52,11 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
           }
 
           if (parentShiftIDsOfRegularShiftsToBeDeleted.indexOf(parentShiftID) != -1) {
-            // If the shift starts within a week, it's a shift that needs to be converted to an
-            // open shift because the open shift job has already run and passed that day.
-            if (Math.abs(moment().diff(moment(shift.start_time, wiwDateFormat), 'days')) < global.config.time_interval.days_in_interval_to_repeat_open_shifts) {
+            /**
+              If the shift starts within two weeks, it's a shift that needs to be converted to an
+              open shift because the open shift job has already run and passed that day.
+            **/
+            if (Math.abs(moment().diff(moment(shift.start_time, wiwDateFormat), 'days')) < config.time_interval.days_of_open_shift_display) {
               var updatedShiftParams = {
                 user_id: 0,
                 notes: ''
@@ -84,12 +81,12 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
 
             if (!deletedShiftInformation.regShifts[parentShiftID]) {
               var formattedStartTime = moment(shift.start_time, wiwDateFormat).tz('America/New_York').format(chooseRegShiftToCancelPageStartDateFormat);
-              var formattedEndTime = moment(shift.end_time, wiwDateFormat).tz('America/New_York').format(chooseRegShiftToCancelPageEndDateFormat)
+              var formattedEndTime = moment(shift.end_time, wiwDateFormat).tz('America/New_York').format(chooseRegShiftToCancelPageEndDateFormat);
               deletedShiftInformation.regShifts[parentShiftID] = { start_time: formattedStartTime, end_time: formattedEndTime };
             }
           }
         }
-        else if (shift.location_id === global.config.locationID.makeup_and_extra_shifts && shiftIDsOfMakeupShiftsToBeDeleted.indexOf(shift.id) != -1) {
+        else if (shift.location_id === config.locationID.makeup_and_extra_shifts && shiftIDsOfMakeupShiftsToBeDeleted.indexOf(shift.id) != -1) {
           var params = {
             user_id : 0
           };
@@ -114,14 +111,14 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
         email: encodeURIComponent(req.query.email),
         token: req.query.token,
         url: 'https://app.wheniwork.com/'
-      }
+      };
 
       var url = '/scheduling/shifts/delete-success?';
       for (var label in templateData) {
         url += label + '=' + templateData[label] + '&';
       }
 
-      var response = {
+      response = {
         success: true,
         redirect: url
       };


### PR DESCRIPTION
#### What's this PR do?
Previously, our model of taking open shifts only allowed users to take weekly shifts from the next week. 

Now, we want to open up our shift model to allow users to take weekly shifts from *the next two weeks.*

This PR modifies the Elmer codebase so that it supports that change. 

#### Annoying, potentially big bug we found
WhenIWork returns shift `start_time` and `end_time` parameters in the following format: "Wed, 01 Jun 2016, 12:00:00 -500". 

However, the timezone doesn't match the format that `moment()` expects when it parses time strings: "-0500". Moment, when it can't properly parse that time string, defaults to creating a date based on the current date. Which is not good. It also fails silently. 

So the following global function added to `config.default.js`, ``MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE`
`, accepts a string returned from WIW formatted like this:
  "Wed, 01 Jun 2016, 12:00:00 -500"
And converts it to a string with the time zone formatted like this:
  "Wed, 01 Jun 2016, 12:00:00 -0500"

#### Where should the reviewer start?
Files with big modifications: 
`recurShifts.js`
`recurOpenShifts.js`

Next, check out how `config.default.js` has changed. 

Minor changes: 
`mergeOpenShifts`
`notifyFirstShift`
`notifyMoreShifts`
`deleteShiftsAndRedirect`

#### How should this be manually tested?
`npm test`
`recurOpenShifts`,  `recurShifts`, `mergeOpenShifts`, `deleteShiftsAndRedirect` tested manually in the test location of WhenIWork. 

#### Any background context you want to provide?
The engineering changes documented in [this spreadsheet](https://docs.google.com/spreadsheets/d/1HuuOyDdU_BGNbJQz-Kb6yRkpko5skCQSvWi1aLQAV3E/edit#gid=0). 
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/browse/INT-31
#### Questions:
