### PR TITLE
add better error handling, debug logging to RecurShifts.js

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -29,7 +29,7 @@ function recurNewlyCreatedShifts() {
 
   WhenIWork.get('shifts', postData, function(response) {
     var allShifts = response.shifts;
-    if (typeof allShifts !== 'object') {
+    if (typeof allShifts !== 'object' || allShifts.length === 0) {
       CONSOLE_WITH_TIME('NO SHIFTS RETURNED.');
       CONSOLE_WITH_TIME('===================');
       CONSOLE_WITH_TIME('RESPONSE: ' + response);
@@ -139,7 +139,17 @@ function recurNewlyCreatedShifts() {
 
           // Getting all shifts created in the timeframe defined above in 'postData' that are unpublished.
           WhenIWork.get('shifts', postData, function(response) {
-            var unpublishedShifts = response.shifts.filter(function(shift) {
+            var unpublishedShifts = response.shifts;
+            if (typeof unpublishedShifts !== 'object' || unpublishedShifts.length === 0) {
+              var errorMessage = 'NO SHIFTS RETURNED FROM CALL FOR UNPUBLISHED SHIFTS.';
+              CONSOLE_WITH_TIME(errorMessage);
+              CONSOLE_WITH_TIME('===================');
+              CONSOLE_WITH_TIME('RESPONSE: ' + response);
+              CONSOLE_WITH_TIME('POST: ' + postData);
+              callback(callback(errorMessage));
+            }
+
+            unpublishedShifts.filter(function(shift) {
               return shift.notes && !shift.published;
             });
 
@@ -170,7 +180,17 @@ function recurNewlyCreatedShifts() {
           };
 
           WhenIWork.get('shifts', postData, function(response) {
-            var unpublishedShifts = response.shifts.filter(function(shift) {
+            var unpublishedShifts = response.shifts;
+            if (typeof unpublishedShifts !== 'object') {
+              var errorMessage = 'NO SHIFTS RETURNED FROM CALL FOR UNPUBLISHED SHIFTS.';
+              CONSOLE_WITH_TIME(errorMessage);
+              CONSOLE_WITH_TIME('===================');
+              CONSOLE_WITH_TIME('RESPONSE: ' + response);
+              CONSOLE_WITH_TIME('POST: ' + postData);
+              callback(callback(errorMessage));
+            }
+
+            unpublishedShifts.filter(function(shift) {
               return shift.notes && !shift.published;
             });
 
@@ -204,13 +224,12 @@ function recurNewlyCreatedShifts() {
   });
 }
 
+// @TODO: remove extraneous logging below, used to debug prod.
 function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
   shift.start_time = MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE(shift.start_time);
   var prevWeekShiftStartTime =  moment(shift.start_time, wiw_date_format, true).add(-1, 'weeks').format(wiw_date_format);
   var nextWeekShiftStartTime = moment(shift.start_time, wiw_date_format, true).add(1, 'weeks').format(wiw_date_format);
   var nextWeekShiftEndTime = moment(shift.start_time, wiw_date_format, true).add(1, 'weeks').add(2, 'hours').format(wiw_date_format);
-  var prevWeekOpenShiftDecremented = false;
-  var nextWeekOpenShiftDecremented = false;
 
   var openShiftQuery = {
     include_open: true,
@@ -220,16 +239,20 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
     end: nextWeekShiftEndTime
   };
 
+  CONSOLE_WITH_TIME('Decrement shifts openShiftQuery: ', openShiftQuery);
+
   WhenIWork.get('shifts', openShiftQuery, function(response) {
     var batchPayload = [];
     var openShifts = response.shifts;
-    if (typeof response !== 'object') {
+    if (typeof openShifts !== 'object' || openShifts.length === 0) {
       CONSOLE_WITH_TIME('NO OPEN SHIFTS RETURNED TO DECREMENT.');
       CONSOLE_WITH_TIME('===================');
       CONSOLE_WITH_TIME('RESPONSE: ' + response);
       CONSOLE_WITH_TIME('POST: ' + postData);
       return;
     }
+
+    CONSOLE_WITH_TIME('Number of shifts to check for decrementing: ', openShifts.length);
 
     openShifts.forEach(function(shift) {
       /**
@@ -257,6 +280,8 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
         }
       }
     });
+
+    CONSOLE_WITH_TIME('Decrement option shifts batch payload request: ', batchPayload);
 
     WhenIWork.post('batch', batchPayload, function(response) {
       CONSOLE_WITH_TIME('Response from decrementing week prior\'s shifts by one, and week after\'s open shifts by one: ', response);


### PR DESCRIPTION
#### What's this PR do?
Adds better error handling, debug logging to RecurShifts.js. 
#### Where should the reviewer start?
#### How should this be manually tested?
Tested on local as working. 
#### Any background context you want to provide?
Strangely enough, it seems like while the `decrementPrevWeeksAndNextWeeksOpenShiftsByOne` function is working locally on test, it doesn't seem to be working on production. 
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/browse/INT-136

