### PR TITLE
add fix for incompatible server/WiW time zone issue

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -256,10 +256,15 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
 
     openShifts.forEach(function(shift) {
       /**
+        Converting every shift's start_time, since prod returns shifts in UTC -700 and our moment is configured for UTC -400. (Testing string equality failed previously.)
+      **/
+      shift.start_time = MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE(shift.start_time);
+      var convertedShiftStartTime = moment(shift.start_time, wiw_date_format, true).format(wiw_date_format);
+      /**
         If the shift is indeed an open shift, and it's the shift that occurs exactly one week
         or after the shift that was just taken, we decrement its instances by one.
       **/
-      if (shift.is_open && (shift.start_time === prevWeekShiftStartTime || shift.start_time === nextWeekShiftStartTime)) {
+      if (shift.is_open && (convertedShiftStartTime === prevWeekShiftStartTime || convertedShiftStartTime === nextWeekShiftStartTime)) {
         var instances = parseInt(shift.instances);
         if (instances === 1) {
           var shiftDeleteRequest = {


### PR DESCRIPTION
#### What's this PR do?
`decrementPrevWeeksAndNextWeeksOpenShiftsByOne` wasn't working, because nothing ever got past this `      if (shift.is_open && (convertedShiftStartTime === prevWeekShiftStartTime || convertedShiftStartTime === nextWeekShiftStartTime)) {`

This was because shifts were being returned by the WiW API in the UTC-0700 timezone. However, when we run moment() on the shifts, we change it to the -0400 time zone since we specify the default timezone as -0400 in `config.js`. So string equality fails. 

This converts every shift's open time in order to check it. 

#### Where should the reviewer start?
#### How should this be manually tested?
Manually tested on local, works. But will it work in prod???? ❓ ❓ 
#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/browse/INT-136
#### Questions:
