### PR TITLE
fix weekly shift recurrence

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -29,7 +29,7 @@ function recurNewlyCreatedShifts() {
 
   WhenIWork.get('shifts', postData, function(response) {
     var allShifts = response.shifts;
-    if (typeof allShifts !== 'object' || allShifts.length === 0) {
+    if (typeof allShifts !== 'object') {
       CONSOLE_WITH_TIME('NO SHIFTS RETURNED.');
       CONSOLE_WITH_TIME('===================');
       CONSOLE_WITH_TIME('RESPONSE: ' + response);
@@ -139,17 +139,7 @@ function recurNewlyCreatedShifts() {
 
           // Getting all shifts created in the timeframe defined above in 'postData' that are unpublished.
           WhenIWork.get('shifts', postData, function(response) {
-            var unpublishedShifts = response.shifts;
-            if (typeof unpublishedShifts !== 'object' || unpublishedShifts.length === 0) {
-              var errorMessage = 'NO SHIFTS RETURNED FROM CALL FOR UNPUBLISHED SHIFTS.';
-              CONSOLE_WITH_TIME(errorMessage);
-              CONSOLE_WITH_TIME('===================');
-              CONSOLE_WITH_TIME('RESPONSE: ' + response);
-              CONSOLE_WITH_TIME('POST: ' + postData);
-              callback(callback(errorMessage));
-            }
-
-            unpublishedShifts.filter(function(shift) {
+            var unpublishedShifts = response.shifts.filter(function(shift) {
               return shift.notes && !shift.published;
             });
 
@@ -180,17 +170,7 @@ function recurNewlyCreatedShifts() {
           };
 
           WhenIWork.get('shifts', postData, function(response) {
-            var unpublishedShifts = response.shifts;
-            if (typeof unpublishedShifts !== 'object') {
-              var errorMessage = 'NO SHIFTS RETURNED FROM CALL FOR UNPUBLISHED SHIFTS.';
-              CONSOLE_WITH_TIME(errorMessage);
-              CONSOLE_WITH_TIME('===================');
-              CONSOLE_WITH_TIME('RESPONSE: ' + response);
-              CONSOLE_WITH_TIME('POST: ' + postData);
-              callback(callback(errorMessage));
-            }
-
-            unpublishedShifts.filter(function(shift) {
+            var unpublishedShifts = response.shifts.filter(function(shift) {
               return shift.notes && !shift.published;
             });
 
@@ -224,7 +204,6 @@ function recurNewlyCreatedShifts() {
   });
 }
 
-// @TODO: remove extraneous logging below, used to debug prod.
 function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
   shift.start_time = MAKE_WIW_TIME_STRING_MOMENT_PARSEABLE(shift.start_time);
   var prevWeekShiftStartTime =  moment(shift.start_time, wiw_date_format, true).add(-1, 'weeks').format(wiw_date_format);
@@ -239,8 +218,6 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
     end: nextWeekShiftEndTime
   };
 
-  CONSOLE_WITH_TIME('Decrement shifts openShiftQuery: ', openShiftQuery);
-
   WhenIWork.get('shifts', openShiftQuery, function(response) {
     var batchPayload = [];
     var openShifts = response.shifts;
@@ -251,8 +228,6 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
       CONSOLE_WITH_TIME('POST: ' + postData);
       return;
     }
-
-    CONSOLE_WITH_TIME('Number of shifts to check for decrementing: ', openShifts.length);
 
     openShifts.forEach(function(shift) {
       /**
@@ -285,8 +260,6 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
         }
       }
     });
-
-    CONSOLE_WITH_TIME('Decrement option shifts batch payload request: ', batchPayload);
 
     WhenIWork.post('batch', batchPayload, function(response) {
       CONSOLE_WITH_TIME('Response from decrementing week prior\'s shifts by one, and week after\'s open shifts by one: ', response);


### PR DESCRIPTION
#### What's this PR do?
Some of the error handling added a few PRs ago broke weekly shift recurrence. 

Strangely enough, we witnessed that the shifts were recurring when we ran on local with test location. But weren't recurring when we ran on local, with prod location. 

After we took out the error handling, things work again. This deserves more attention in the future. 

#### Where should the reviewer start?
#### How should this be manually tested?
Manually tested on local with prod and test locations. 
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Questions:

