### PR TITLE
Create sortUsersByShifts for refactored NotifyMoreShifts that uses co…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,6 @@ node_modules
 keys.js
 
 # WiW Response sampler
-test/helpers/httpResponse.json
 test/helpers/sampleResponse
 
 # Elastic Beanstalk Files

--- a/config.js
+++ b/config.js
@@ -52,7 +52,12 @@ CONFIG.locationID = {
   test: 990385,
   test2: 1007104,
   supervisors: 884473,
-  crisis_counselors_demo: 1004215
+  supervisor_on_platform: 995815
+};
+
+CONFIG.wiwAccountID = {
+  CCs: 549781,
+  supervisors: 622060,
 };
 
 CONFIG.time_interval = {
@@ -67,6 +72,9 @@ CONFIG.time_interval = {
 
   // How often do we create new openshifts and merge duplicate openshifts
   open_shifts: '0 0 */2 * * *', // every two hours
+
+  // Runs twice a day / every twelve hours
+  cron_twice_per_day: '0 0 */12 * * *',
 
   // How often do we notify users to take more shifts
   take_more_shifts_cron_job_string: '30 5 18 * * *', // Every day at 6:05:30 pm
@@ -90,7 +98,10 @@ CONFIG.time_interval = {
   months_to_search_for_time_off_requests: 6,
 
   // How many days in advance we show open shifts
-  days_of_open_shift_display: 15
+  days_of_open_shift_display: 15,
+
+  // Number of days in a week
+  one_week: 7
 };
 
 CONFIG.numberOfCounselorsPerShift = {

--- a/email_templates/composeNotifyMoreShifts.js
+++ b/email_templates/composeNotifyMoreShifts.js
@@ -1,0 +1,62 @@
+var moment = require('moment');
+var date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+
+function composeEmail (user, shiftToSup) {
+  var body = composeSupTiles(user.shifts[0], shiftToSup);
+
+  var shifts = [];
+
+  user.shifts.forEach(function(shift){
+    shifts.push(moment(shift, date_format).format("dddd, MMMM Do YYYY, h:mm a") + " ET");
+  });
+
+  shifts = shifts.join('</p> <p>');
+
+  var intro = "<div>" +
+    "<p> Hey " + user.firstName + "! </p>" +
+    "<p> Woohoo! You signed up for " + user.shifts.length + " weekly shifts. We've got you down for: </p>" +
+    "<p>"+ shifts + "</p>" +
+    "<p> As promised, you'll be in good hands. Here are the supervisors who will have your back on your first shift: </p>" +
+    "<div style='display: flex; text-align:center'>";
+
+  var conclusion = "</div>" +
+   "<p> Our supervisors are amazeballs. They're also human beings who take vacations and get sick - if your super above isn’t online for your shift, don't fret. You’ll be in good hands with someone else on our team. Here are a few pro tips for the platform: </p>" +
+    "<ul>" +
+      "<li>Your supervisor's name is on the upper left corner of your screen (click it and say hello!)</li>" +
+      "<li>Enter your status under your name (suggestion: &#34First Shift&#34 - or some funky version of this, so your fellow crisis counselors know to say hi!)</li>" +
+      "<li>Only take 1 conversation at a time</li>" +
+      "<li>NEVER feel like you are alone, your peers and supervisors are there to help!</li>" +
+      "<li>Say hi to everyone in the Global Chat let them know you are new - join the convo (it's a fun crew!)</li>" +
+      "<li>If you need to make any changes to your schedule, or aren't able to make your first shift please visit CTL Online and click on &#34Shift Scheduling&#34.</li>" +
+    "</ul> " +
+    "<p> Taking your first shift is the last step in becoming a bona fide Crisis Counselor! You got this!</p>" +
+    "<p> Enjoy your first shift, </p> " +
+    "<p> The Crisis Text Line Training Team </p>" +
+  "</div>";
+
+  return intro + body + conclusion;
+}
+
+function composeSupTiles (shift, shiftToSup) {
+  var supTileHTML = '';
+  // Supervisors schedule shifts every 4 hours, CCs every 2 hours so check both supervisor slots
+  // Technically I should be checking to see which supervisors started within the last 4 hours.
+  // TODO make this more robust...
+  var altShift = moment(shift, date_format).subtract(2, 'hours').format(date_format);
+
+  if (shiftToSup[shift]) shiftToSup[shift].forEach(addText);
+  if (shiftToSup[altShift]) shiftToSup[altShift].forEach(addText);
+
+  function addText (sup){
+    var fullName = sup.first + " " + sup.last;
+    supTileHTML += '<div style="padding: 10px; border:1px solid black; width:160px; margin: 10px;">' +
+    fullName + ' <br> ' +
+    '<img src=' + sup.imgURL + ' alt="'+ fullName+ '" height="150" width="150">' +
+    '</div>';
+  }
+
+  return supTileHTML;
+}
+
+module.exports = composeEmail;
+

--- a/jobs/scheduling/helpers/sortUsersByShift.js
+++ b/jobs/scheduling/helpers/sortUsersByShift.js
@@ -1,0 +1,79 @@
+/**
+Purpose: Get shifts from When I Work and sort users by which shift they are signed up for
+Input should be the WiW API to call (user or supervisor) and callback for how to use the output
+Data is hashed by shift start time: [users scheduled];
+
+Example for using supervisor API:
+var wIW = require('wheniwork-unofficial');
+var apiSup = wIW.apiWithOptons({
+  key: KEYS.wheniwork.api_key, 
+  email: KEYS.wheniwork.username, 
+  password: KEYS.wheniwork.password,
+  companyName: "Crisis Text Line Supervisors"
+});
+var fs = require('fs');
+
+// sortUsersByShift(apiSup, 995815)
+// .then(writeToFile);
+
+function writeToFile (text) {
+  fs.writeFile('../../../test/helpers/sampleResponse/testingSupervisorsResponse.json', JSON.stringify(text), (err) => {
+    if (err) throw err;
+    console.log('It\'s saved!');
+  });
+}
+
+**/
+
+var gravatar = require('gravatar');
+
+function sortUsersByShift(apiToCall, locationId, correctAccountID) {
+  var shiftSearchParams = {
+    end: '+' + CONFIG.time_interval.one_week  + ' days',
+    location_id: locationId
+  };
+  return new Promise(function(resolve, reject) {
+    apiToCall.get('shifts', shiftSearchParams, function(response) {
+      try {
+        var userIdToInfo = matchUserIdToInfo(response.users, correctAccountID);
+        var shiftToUserObj = matchShiftToUserId(response.shifts, userIdToInfo);
+        resolve(shiftToUserObj);
+      }
+      catch(err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function matchUserIdToInfo (users, correctAccountID) {
+  var supsById = {};
+
+  users.forEach(function(user) {
+    // This if statement insures that the users are from the appropriate 'company' in case WiW sends back the wrong ones
+    if (user.account_id === correctAccountID){
+      supsById[user.id] = {
+        first: user.first_name,
+        last: user.last_name,
+        email: user.email,
+        imgURL: gravatar.url(user.email, {protocol: 'https',  s: '200'}),
+      };
+    }
+  });
+
+  return supsById;
+}
+
+function matchShiftToUserId(shifts, supsById) {
+  var shiftStartToUsers = {};
+
+  shifts.forEach(function(shift){
+    // Each shift start time will key to an array of supervisor objects
+    if (!shiftStartToUsers[shift.start_time]) shiftStartToUsers[shift.start_time] = [];
+    shiftStartToUsers[shift.start_time].push(supsById[shift.user_id]);
+  });
+
+  return shiftStartToUsers;
+}
+
+module.exports = sortUsersByShift;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "debug": "~0.7.4",
     "express": "~4.0.0",
     "forever": "^0.15.1",
+    "gravatar": "^1.5.2",
     "jade": "~1.3.0",
     "mandrill-api": "^1.0.45",
     "moment": "^2.11.0",

--- a/test/helpers/checkHTTPResponses.js
+++ b/test/helpers/checkHTTPResponses.js
@@ -1,15 +1,15 @@
 /**
   This file was created in order to attain sample data from WiW for use 
   with testing. Modify the get request below as desired and retrieved data will 
-  be written to httpResonse.json. 
+  be written to sampleResponse. 
 **/
 
 var moment = require('moment-timezone');
 var fs = require('fs');
 
 var wIW = require('wheniwork-unofficial');
-var KEYS = require('../../keys.js');
-var CONFIG = require('../../config.js');
+global.KEYS = require('../../keys.js');
+global.CONFIG = require('../../config.js');
 var WhenIWork = new wIW(KEYS.wheniwork.api_key, KEYS.wheniwork.username, KEYS.wheniwork.password);
 
 var date_format = 'YYYY-MM-DD HH:mm:ss';
@@ -17,7 +17,6 @@ var date_format = 'YYYY-MM-DD HH:mm:ss';
 // sendRequest('request', timeOffRequests());
 // sendRequest('users', usersRequests());
 sendRequest('shifts', shiftsRequests());
-
 
 function timeOffRequests() {
   //Using moment.js to format time as WIW expects
@@ -35,7 +34,7 @@ function timeOffRequests() {
 
 function usersRequests() {
   var usersSearchParams = {
-    location_id: CONFIG.locationID.test
+    location_id: CONFIG.locationID.regular_shifts
   };
 
   return usersSearchParams;
@@ -54,11 +53,44 @@ function sendRequest (term, params) {
   //Get all time off requests within timeOffSearchParams
   WhenIWork.get(term, params, function(response) {
     console.log(`${term} returns ${response}`);
-    fs.writeFile('httpResponse.json', JSON.stringify(response), (err) => {
+    fs.writeFile(`sampleResponse/httpResponse1${capitalizeFirstLetter(term)}.json`, JSON.stringify(response), (err) => {
       if (err) throw err;
       console.log('It\'s saved!');
     });
   });
-
-
 }
+
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/** Started working on creating new users for Kaley 
+// var newUser = {
+//   role: 3,
+//   email: "admin+wheeliecj@gmail.com@crisistextline.org",
+//   first_name: "Carlie",
+//   last_name: "Wheeler",
+//   activated: true,
+//   locations: [CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts],
+//   password: KEYS.wheniwork.default_password,
+//   notes: JSON.stringify({ canonicalEmail: 'wheeliecj@gmail.com'})
+// };
+// api.post('users', newUser, function (data) {
+//   var api2 = new WhenIWork(KEYS.wheniwork.api_key, altEmail, KEYS.wheniwork.default_password, function (data) {
+//   });
+
+//   var alert = {sms: false, email: false};
+//   var alerts = ['timeoff', 'swaps', 'schedule', 'reminders', 'availability', 'new_employee', 'attendance'];
+//   var postBody = {};
+
+//   for (var i in alerts) {
+//     postBody[alerts[i]] = alert;
+//   }
+
+//   callback(data);
+//   api2.post('users/alerts', postBody, function () {});
+//   api2.post('users/profile', {email: email}, function (profile) {
+//     callback(profile.user);
+//   });
+// });
+**/


### PR DESCRIPTION
#### What's this PR do?
sortUserByShifts - gets shifts from WiW and resorts them into shiftStartTime: Users signed up for that shift. - This is specifically meant to find out which supervisors are scheduled for specific shifts, but is also able to run with the origin WiW API for CCs
NotifyMoreShifts - modified to keep track of which data 
#### Where should the reviewer start?
sortUserByShifts
#### How should this be manually tested?
NotifyMoreShifts can be run locally if WiW-Unofficial is updated. - The way I coded that may relate to the inconsistency I'm getting from WiW.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&selectedIssue=INT-112
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-114
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-115
#### Questions:
I'm using some ES6 in here that I can remove - I've included more specific questions in comments.
Does it make sense to merge this in before WiW Unofficial is updated?