### PR TITLE
Added code to NotifyMoreShifts that triggers a Canvas update giving u…

### DIFF
--- a/jobs/scheduling/NotifyMoreShifts.js
+++ b/jobs/scheduling/NotifyMoreShifts.js
@@ -5,6 +5,7 @@
 // var wiw = require('wheniwork-unofficial');
 // var wIWSupervisorsAPI = new wiw(KEYS.wheniwork.api_key, KEYS.wheniwork.username, KEYS.wheniwork.password, "Crisis Text Line Supervisors");
 
+// var updateCanvas = require('./updateCanvas.js');
 // var stathat = require(CONFIG.root_dir + '/lib/stathat');
 // var moment = require('moment');
 // var retrieveAndSortSupervisorsByShift = require('./helpers/sortUsersByShift');
@@ -127,13 +128,16 @@ function twoShiftNotification(users, usersToNotify) {
           params: {notes: JSON.stringify(user_data)}
         });
 
+        var email = user_data.canonicalEmail ? user_data.canonicalEmail : user.email;
+
         usersBeingNotified[user.id] = {
           firstName: user.first_name,
           lastName: user.last_name,
-          email: user_data.canonicalEmail ? user_data.canonicalEmail : user.email,
+          email: email,
           shifts: usersToNotify[user.id]
         };
         
+        updateCanvas.findWiWUserInCanvas(user.first_name + " " + user.last_name, email);
       }
     }
 


### PR DESCRIPTION
#### What's this PR do?
Adds two lines of code to NotifyMoreShifts that hooks up updateCanvas functionality. At the same time that a user gets a notification that they have taken their first two plus shifts, they will also get credit in Canvas for the scheduling shifts assignment.
#### Where should the reviewer start?
jobs/scheduling/NotifyMoreShifts, line 138, and jobs/scheduling/updateCanvas.js.
#### How should this be manually tested?
node NotifyMoreShifts and/or updateCanvas.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-96](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-96)
#### Questions:

…sers credit for the scheduling shifts assignment.