### PR TITLE
Added 'see my updated schedule' button to the page shown after some s…

### DIFF
--- a/www/views/scheduling/someShiftsCancelled.jade
+++ b/www/views/scheduling/someShiftsCancelled.jade
@@ -26,3 +26,8 @@ block content
         input(type="hidden", name="email", value=email)
         input(type="hidden", name="token", value=token)
         input(type="submit", value="Delete other shifts")
+
+    form(action="/scheduling/login", method="get")
+        input(type="hidden", name="email", value=email)
+        input(type="hidden", name="token", value=token)
+        input(type="submit", value="See my updated schedule")


### PR DESCRIPTION
#### What's this PR do?
It adds a button to the page that CCs see after they delete some shifts from their schedule. The button sends CCs to WiW to look at their updated schedule.
#### Where should the reviewer start?
www/views/scheduling/someShiftsCancelled.jade
#### How should this be manually tested?
Create shifts for yourself in the test environment. Run www/app.js in node. If you need to recur your shift, node runJobs.js. Delete one of your shifts at "http://localhost:3000/scheduling/shifts" (use your email and token). You should then be sent to the shifts cancelled page.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-185](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-185)
#### Questions:

…hifts are deleted.