### PR TITLE
Refactored for pulling WiW accounts from up to 21 days back and using…

### DIFF
--- a/config.js
+++ b/config.js
@@ -116,7 +116,7 @@ CONFIG.time_interval = {
   // How many days in advance we show open shifts
   days_of_open_shift_display: 15,
 
-  // How many days until we consider users no longer new
+  // How many days until we consider users no longer new--we use this in checking for new WiW users who have booked first shifts
   days_until_older_user: 21,
 
   // Number of days in a week

--- a/jobs/scheduling/NotifyMoreShifts.js
+++ b/jobs/scheduling/NotifyMoreShifts.js
@@ -2,7 +2,7 @@ var CronJob = require('cron').CronJob;
 var wIWUserAPI = CONFIG.WhenIWork;
 var wIWSupervisorsAPI = CONFIG.WhenIWorkSuper;
 
-var updateCanvas = require('./updateCanvas.js');
+var updateCanvas = require('./helpers/updateCanvas.js');
 var stathat = require(CONFIG.root_dir + '/lib/stathat');
 var moment = require('moment');
 var retrieveAndSortSupervisorsByShift = require('./helpers/sortUsersByShift');
@@ -86,7 +86,7 @@ function listUsersWithTwoOrMoreShifts(users) {
 function removeOlderUsers (users) {
   return users.filter(function(user) {
     var created = moment(new Date(user.created_at));
-    return moment().diff(created, 'days') < CONFIG.time_interval.days_of_open_shift_display;
+    return moment().diff(created, 'days') < CONFIG.time_interval.days_until_older_user;
   });
 }
 
@@ -136,7 +136,7 @@ function twoShiftNotification(users, usersToNotify) {
           shifts: usersToNotify[user.id]
         };
         
-        updateCanvas.findWiWUserInCanvas(user.first_name + " " + user.last_name, email);
+        updateCanvas.findWiWUserInCanvas(email);
       }
     }
 

--- a/test/updateCanvas.js
+++ b/test/updateCanvas.js
@@ -1,12 +1,14 @@
 var assert = require('assert');
-var updateCanvas = require('../jobs/scheduling/updateCanvas.js');
+var updateCanvas = require('../jobs/scheduling/helpers/updateCanvas.js');
 var WiWUser = [7889841];
 var canvasUser = 1734;
+var trainingCourseID = 49;
+var scheduleYourShiftsAssignmentID = 676;
 
 describe('update Canvas', function() {
 
     it('gives a user a passing grade in Canvas on the "Schedule Your Shifts" assignment', function (done) {
-      updateCanvas.updateUserGradeInCanvas(canvasUser, 60, 921)
+      updateCanvas.canvas.updateUserGrade(canvasUser, trainingCourseID, scheduleYourShiftsAssignmentID, 'complete')
       .then(function(result) {
         assert.equal(result.grade, 'complete');
         done();
@@ -16,13 +18,13 @@ describe('update Canvas', function() {
     it('can scrape Canvas to find courses a user is enrolled in', function (done) {
       updateCanvas.canvas.scrapeCanvasEnrollment(canvasUser)
       .then(function(result) {
-        assert.equal(result[0].course_id, 60);
+        assert.equal(result[0].course_id, 67);
         done();
       });
     });
 
     it('can scrape Canvas to match a WiW user to a Canvas user', function (done) {
-      updateCanvas.canvas.scrapeCanvasUsers('John Rauschenberg')
+      updateCanvas.canvas.scrapeCanvasUsers('john@crisistextline.org')
       .then(function(result) {
         assert.equal(result[0].id, 1734);
         done();
@@ -30,9 +32,9 @@ describe('update Canvas', function() {
     });
 
     it('can scrape Canvas to find assignments in a course matching a filter', function (done) {
-      updateCanvas.canvas.scrapeCanvasAssignments(60, 'Schedule Your Shifts')
+      updateCanvas.canvas.scrapeCanvasAssignments(trainingCourseID, 'Schedule Your Shifts')
       .then(function(result) {
-        assert.equal(result[0].id, 921);
+        assert.equal(result[0].id, scheduleYourShiftsAssignmentID);
         done();
       });
     });


### PR DESCRIPTION
#### What's this PR do?
It fixes some behavior in NotifyMoreShifts and updateCanvas that was not allowing users who scheduled their first two shifts in WiW from getting credit in Canvas. Specifically, it now polls WiW 21 days back instead of 15, since some users created their WiW accounts more than 15 days before they scheduled their first shifts. Also, it allows for users to be identified across WiW and Canvas by just their email, rather than requiring both their name and email to match.
#### Where should the reviewer start?
NotifyMoreShifts, updateCanvas, config.js
#### How should this be manually tested?
npm test or node NotifyMoreShifts
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-218
](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-218)#### Questions:

… email only to ID users across Canvas and WiW.