### PR TITLE
Notify users via email anyime they book a new recurring shift

### DIFF
--- a/config.js
+++ b/config.js
@@ -116,6 +116,9 @@ CONFIG.time_interval = {
   // How many days in advance we show open shifts
   days_of_open_shift_display: 15,
 
+  // How many days until we consider users no longer new
+  days_until_older_user: 21,
+
   // Number of days in a week
   one_week: 7
 };

--- a/email_templates/composeNotifyBookedShift.js
+++ b/email_templates/composeNotifyBookedShift.js
@@ -1,0 +1,45 @@
+var moment = require('moment');
+var date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+
+function composeEmail (user, shiftToSup) {
+  var body = composeSupTiles(user.shift, shiftToSup);
+
+  var shift = moment(user.shift, date_format).format("dddd, MMMM Do YYYY, h:mm a") + " ET";
+
+  var intro = "<div>" +
+    "<p> Hey " + user.first_name + "! </p>" +
+    "<p> Woohoo! You signed up for a new weekly shift at " + shift + " .</p>" +
+    "<p> These are the supervisors who will have your back on the platform: </p>" +
+    "<div style='display: flex; text-align:center'>";
+
+  var conclusion = "</div>" +
+   "<p> Our team of supervisors is amazeballs. We're also human beings who take vacations and get sick - if your super above isn't online for your shift, don't fret. You'll be in good hands with someone else on our team. </p>" +
+    "<p> Enjoy your shift, </p> " +
+    "<p> The Crisis Text Line Supervisors </p>" +
+  "</div>";
+
+  return intro + body + conclusion;
+}
+
+function composeSupTiles (shift, shiftToSup) {
+  var supTileHTML = '';
+  // Supervisors schedule shifts every 4 hours, CCs every 2 hours so check both supervisor slots
+
+  var altShift = moment(shift, date_format).subtract(2, 'hours').format(date_format);
+
+  if (shiftToSup[shift]) shiftToSup[shift].forEach(addText);
+  if (shiftToSup[altShift]) shiftToSup[altShift].forEach(addText);
+
+  function addText (sup){
+    var fullName = sup.first + " " + sup.last;
+    supTileHTML += '<div style="padding: 10px; border:1px solid black; width:160px; margin: 10px;">' +
+    fullName + ' <br> ' +
+    '<img src=' + sup.imgURL + ' alt="'+ fullName+ '" height="150" width="150">' +
+    '</div>';
+  }
+
+  return supTileHTML;
+}
+
+module.exports = composeEmail;
+

--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var async = require('async');
 var wiw_date_format = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 var stathat = require(CONFIG.root_dir + '/lib/stathat');
+var notifyUserBookedShift = require('./helpers/notifyUserBookedShift');
 
 new CronJob(CONFIG.time_interval.recur_and_publish_shifts_cron_job_string, function () {
   recurNewlyCreatedShifts();
@@ -48,6 +49,7 @@ function recurNewlyCreatedShifts(optionalNoShiftsForTesting) {
     var newShifts = allShifts.filter(function(shift) {
       return !shift.notes;
     });
+    if (newShifts.length) notifyUserBookedShift.notifyUserBookedShift(newShifts, response.users);
 
     stathat.increment('Scheduling - Shifts Recurred', newShifts.length);
 

--- a/jobs/scheduling/helpers/notifyUserBookedShift.js
+++ b/jobs/scheduling/helpers/notifyUserBookedShift.js
@@ -1,0 +1,66 @@
+var wIWSupervisorsAPI = CONFIG.WhenIWorkSuper;
+var moment = require('moment');
+var retrieveAndSortSupervisorsByShift = require('./sortUsersByShift');
+var composeEmail = require(CONFIG.root_dir + '/email_templates/composeNotifyBookedShift');
+var mandrill = require('mandrill-api/mandrill');
+var mandrill_client = new mandrill.Mandrill(KEYS.mandrill.api_key);
+
+function notifyUserBookedShift (shifts, users) {
+  var userIdToInfo = filterUsersToObject(users);
+  retrieveAndSortSupervisorsByShift(wIWSupervisorsAPI, CONFIG.locationID.supervisor_on_platform, CONFIG.wiwAccountID.supervisors)
+  .then(function(shiftsToSup){
+    mandrillEachUser(shifts, userIdToInfo, shiftsToSup);  
+  })
+  .catch(function(err){
+    CONSOLE_WITH_TIME(err);
+  });
+}
+
+function filterUsersToObject (users){
+  var usersObj = {};
+  users.forEach(function(user){
+    var created = moment(new Date(user.created_at));
+    // Only includes users who have already received the two_shift_notification note
+    // or are at least 'days_of_open_shift_display' old and will never get that user note
+    if (/two_shift_notification/.test(user.notes) || moment().diff(created, 'days') >= CONFIG.time_interval.days_until_older_user) usersObj[user.id] = user;
+  });
+  return usersObj;
+}
+
+function mandrillEachUser (shifts, userIdToInfo, shiftsToSup){
+  var results = [];
+  var contents;
+  
+  shifts.forEach(function(shift){
+    var user = userIdToInfo[shift.user_id];
+    user.shift = shift.start_time;
+
+    contents = composeEmail(user, shiftsToSup);
+    results.push(contents);
+
+    // if the user has canonicalEmail in their notes use that, otherwise use user.email.
+    var email = /canonicalEmail/.test(user.notes) ? JSON.parse(user_data).canonicalEmail : user.email;
+
+    var message = {
+      subject: "You're signed up for a new CTL shift!",
+      html: contents,
+      from_email: 'supervisors@crisistextline.org',
+      from_name: 'Crisis Text Line',
+      to: [{
+          email: email,
+          name: user.first_name + ' ' + user.last_name,
+          type: 'to'
+      }],
+      headers: {
+          "Reply-To": "support@crisistextline.org",
+      }
+    };
+
+    mandrill_client.messages.send({message: message}, CONSOLE_WITH_TIME);
+  });
+
+  // results are returned for testing.
+  return results;
+}
+
+module.exports = {notifyUserBookedShift: notifyUserBookedShift};


### PR DESCRIPTION
#### What's this PR do?
Emails any users that booked a shift after they have received their second_shift_notification (or are too old to)
#### Where should the reviewer start?
#### How should this be manually tested?
 1) Change the runJobs file to only run this
 2) Book a new shift on whenIwork with an account that has already received second_shift_notification or more than the designated age
3) node runJobs 
4) make sure you get an email about your newly booked shift
#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-164
#### Questions:

