### PR TITLE
Drop melted users

### DIFF
--- a/jobs/scheduling/dropMeltedUsers.js
+++ b/jobs/scheduling/dropMeltedUsers.js
@@ -1,117 +1,62 @@
-global.CONFIG = require('../../config.js');
-global.KEYS = require('../../keys.js')
 var Request = require('request-promise');
+var CronJob = require('cron').CronJob;
 var WhenIWork = CONFIG.WhenIWork;
-var mandrill = require('mandrill-api/mandrill');
-var mandrill_client = new mandrill.Mandrill(KEYS.mandrill.api_key);
+var updateCanvas = require('./helpers/updateCanvas.js');
+var fs = require('fs');
 var options = {
   headers: {
     Authorization: KEYS.canvas.api_key,
     'User-Agent': 'Request-Promise'
   }
 };
-var canvas = {};
 
-//finds all canvas courses
-canvas.scrapeCanvasCourses = function() {
+new CronJob(CONFIG.time_interval.cron_twice_per_day, findMeltedCanvasUsersAndDeleteThemInWiW, null, true);
 
-  options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/courses?per_page=1000';
-
-  return Request(options)
-  .then(function(response){
-    if (response === '[]') throw 'No courses found.';
-    response = JSON.parse(response);
-    return response;
-  })
-  .catch(function(err){
-    CONSOLE_WITH_TIME('Canvas call to get courses failed: ', err);
-  });
-
-};
-
-//finds all enrollments in a given course
-canvas.scrapeCanvasEnrollment = function(courseID, enrollmentState) {
-
-  options.url = 'https://crisistextline.instructure.com/api/v1/courses/' + courseID + '/enrollments?state[]=' + enrollmentState;
-
-  return Request(options)
-  .then(function(response){
-    response = JSON.parse(response);
-    return response;
-  })
-  .catch(function(err){
-    CONSOLE_WITH_TIME("Finding enrollments for the course with ID " + courseID + " in Canvas failed: ", err);
-  });
-
-};
-
-canvas.emailDroppedUser = function(user) {
-  var message = {
-    subject: 'Melted',
-    html: 'You got melted, son.',
-    from_email: 'support@crisistextline.org',
-    from_name: 'Crisis Text Line',
-    to: [{
-        email: user.login_id,
-        name: user.name,
-        type: 'to'
-    }],
-    headers: {
-        "Reply-To": "support@crisistextline.org",
-    }
-  };
-
-  mandrill_client.messages.send({message: message}, CONSOLE_WITH_TIME);
-
-  //the below is returned for testing purposes
-  return message;
-};
-
-deleteWiWUserAndShifts = function(canvasUser) {
+function deleteWiWUserAndShifts(canvasUser, WiWUsers) {
   var usersForTest;
-  WhenIWork.get('users', CONFIG.locationID.regular_shifts, function(users) {
-    users = users.users.filter(function(user) {
-      return user.email == canvasUser.login_id;
-    });
-    users = users.map(function(user) {
-      return user.id;
-    });
-    for (var userID in users) {
-      // WhenIWork.delete('users', {id: userID, delete_shifts: false}, function(result) {
-      //   CONSOLE_WITH_TIME("Successfully deleted user: ", result);
-      // });
-    }
-    usersForTest = users;
+  WiWUsers = WiWUsers.users.filter(function(user) {
+    return user.email == canvasUser.login_id;
   });
-  return usersForTest;
-};
-
-function findMeltedCanvasUsersEmailThemAndDeleteThemInWiW() {
-  canvas.scrapeCanvasCourses()
-  .then(function(response) {
-    var result = response.map(function(course) {
-      return course.id;
+  WiWUsers = WiWUsers.map(function(user) {
+    return user.id;
+  });
+  for (var i=0; i<WiWUsers.length; i++) {
+    WhenIWork.delete('users/' + WiWUsers[i], function(result) {
+      CONSOLE_WITH_TIME("Successfully deleted user " + WiWUsers[i] + ": ", result);
     });
-    return result;
-  })
-  .then(function(courseIDs) {
-    courseIDs.forEach(function(courseID) {
-      return canvas.scrapeCanvasEnrollment(courseID, 'inactive')
-      .then(function(enrollments) {
-        enrollments.forEach(function(enrollment) {
-          //take user object here and delete user's WiW shifts + account, email person
-          canvas.emailDroppedUser(enrollment.user);
-          deleteWiWUserAndShifts(enrollment.user);
+  }
+  usersForTest = WiWUsers;
+  return usersForTest;
+}
+
+function findMeltedCanvasUsersAndDeleteThemInWiW() {
+  WhenIWork.get('users', CONFIG.locationID.regular_shifts, function(users) {
+    updateCanvas.canvas.retrieveCourses()
+    .then(function(response) {
+      var result = response.map(function(course) {
+        return course.id;
+      });
+      return result;
+    })
+    .then(function(courseIDs) {
+      courseIDs.forEach(function(courseID) {
+        return updateCanvas.canvas.retrieveEnrollment(courseID, 'inactive')
+        .then(function(enrollments) {
+          if (!enrollments) throw 'No inactive enrollments found.';
+          enrollments.forEach(function(enrollment) {
+            //take user object here and delete user's WiW shifts + account
+            deleteWiWUserAndShifts(enrollment.user, users);
+          });
+        })
+        .catch(function(error) {
+          console.log('Error finding Canvas users or deleting them in WiW', error);
         });
       });
+    })
+    .catch(function(err) {
+      console.log('Error finding Canvas users or deleting them in WiW', err);
     });
-  })
-  .catch(function(err) {
-    console.log('Error finding Canvas users or deleting them in WiW', err);
   });
 }
 
-findMeltedCanvasUsersEmailThemAndDeleteThemInWiW();
-
-module.exports = {deleteWiWUserAndShifts: deleteWiWUserAndShifts, findMeltedCanvasUsersEmailThemAndDeleteThemInWiW: findMeltedCanvasUsersEmailThemAndDeleteThemInWiW, canvas: canvas};
-
+module.exports = {deleteWiWUserAndShifts: deleteWiWUserAndShifts, findMeltedCanvasUsersAndDeleteThemInWiW: findMeltedCanvasUsersAndDeleteThemInWiW};

--- a/jobs/scheduling/dropMeltedUsers.js
+++ b/jobs/scheduling/dropMeltedUsers.js
@@ -1,0 +1,117 @@
+global.CONFIG = require('../../config.js');
+global.KEYS = require('../../keys.js')
+var Request = require('request-promise');
+var WhenIWork = CONFIG.WhenIWork;
+var mandrill = require('mandrill-api/mandrill');
+var mandrill_client = new mandrill.Mandrill(KEYS.mandrill.api_key);
+var options = {
+  headers: {
+    Authorization: KEYS.canvas.api_key,
+    'User-Agent': 'Request-Promise'
+  }
+};
+var canvas = {};
+
+//finds all canvas courses
+canvas.scrapeCanvasCourses = function() {
+
+  options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/courses?per_page=1000';
+
+  return Request(options)
+  .then(function(response){
+    if (response === '[]') throw 'No courses found.';
+    response = JSON.parse(response);
+    return response;
+  })
+  .catch(function(err){
+    CONSOLE_WITH_TIME('Canvas call to get courses failed: ', err);
+  });
+
+};
+
+//finds all enrollments in a given course
+canvas.scrapeCanvasEnrollment = function(courseID, enrollmentState) {
+
+  options.url = 'https://crisistextline.instructure.com/api/v1/courses/' + courseID + '/enrollments?state[]=' + enrollmentState;
+
+  return Request(options)
+  .then(function(response){
+    response = JSON.parse(response);
+    return response;
+  })
+  .catch(function(err){
+    CONSOLE_WITH_TIME("Finding enrollments for the course with ID " + courseID + " in Canvas failed: ", err);
+  });
+
+};
+
+canvas.emailDroppedUser = function(user) {
+  var message = {
+    subject: 'Melted',
+    html: 'You got melted, son.',
+    from_email: 'support@crisistextline.org',
+    from_name: 'Crisis Text Line',
+    to: [{
+        email: user.login_id,
+        name: user.name,
+        type: 'to'
+    }],
+    headers: {
+        "Reply-To": "support@crisistextline.org",
+    }
+  };
+
+  mandrill_client.messages.send({message: message}, CONSOLE_WITH_TIME);
+
+  //the below is returned for testing purposes
+  return message;
+};
+
+deleteWiWUserAndShifts = function(canvasUser) {
+  var usersForTest;
+  WhenIWork.get('users', CONFIG.locationID.regular_shifts, function(users) {
+    users = users.users.filter(function(user) {
+      return user.email == canvasUser.login_id;
+    });
+    users = users.map(function(user) {
+      return user.id;
+    });
+    for (var userID in users) {
+      // WhenIWork.delete('users', {id: userID, delete_shifts: false}, function(result) {
+      //   CONSOLE_WITH_TIME("Successfully deleted user: ", result);
+      // });
+    }
+    usersForTest = users;
+  });
+  return usersForTest;
+};
+
+function findMeltedCanvasUsersEmailThemAndDeleteThemInWiW() {
+  canvas.scrapeCanvasCourses()
+  .then(function(response) {
+    var result = response.map(function(course) {
+      return course.id;
+    });
+    return result;
+  })
+  .then(function(courseIDs) {
+    courseIDs.forEach(function(courseID) {
+      return canvas.scrapeCanvasEnrollment(courseID, 'inactive')
+      .then(function(enrollments) {
+        enrollments.forEach(function(enrollment) {
+          //take user object here and delete user's WiW shifts + account, email person
+          canvas.emailDroppedUser(enrollment.user);
+          deleteWiWUserAndShifts(enrollment.user);
+        });
+      });
+    });
+  })
+  .catch(function(err) {
+    console.log('Error finding Canvas users or deleting them in WiW', err);
+  });
+}
+
+findMeltedCanvasUsersEmailThemAndDeleteThemInWiW();
+
+module.exports = {deleteWiWUserAndShifts: deleteWiWUserAndShifts, findMeltedCanvasUsersEmailThemAndDeleteThemInWiW: findMeltedCanvasUsersEmailThemAndDeleteThemInWiW, canvas: canvas};
+

--- a/jobs/scheduling/helpers/updateCanvas.js
+++ b/jobs/scheduling/helpers/updateCanvas.js
@@ -41,6 +41,38 @@ canvas.scrapeCanvasUsers = function(email) {
 
 };
 
+canvas.retrieveCourses = function() {
+
+  options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/courses?per_page=1000';
+
+  return Request(options)
+  .then(function(response){
+    response = JSON.parse(response);
+    if (Array.isArray(response) && response.length === 0) throw 'No courses found.';
+    return response;
+  })
+  .catch(function(err){
+    CONSOLE_WITH_TIME('Canvas call to get courses failed: ', err);
+  });
+
+};
+
+//finds all enrollments in a given course
+canvas.retrieveEnrollment = function(courseID, enrollmentState) {
+
+  options.url = 'https://crisistextline.instructure.com/api/v1/courses/' + courseID + '/enrollments?state[]=' + enrollmentState;
+
+  return Request(options)
+  .then(function(response){
+    response = JSON.parse(response);
+    return response;
+  })
+  .catch(function(err){
+    CONSOLE_WITH_TIME("Finding enrollments for the course with ID " + courseID + " in Canvas failed: ", err);
+  });
+
+};
+
 //finds all courses a specific user is enrolled in
 canvas.scrapeCanvasEnrollment = function(userID) {
 

--- a/test/dropMeltedUsers.js
+++ b/test/dropMeltedUsers.js
@@ -1,42 +1,34 @@
 var assert = require('assert');
 var dropMeltedUsers = require('../jobs/scheduling/dropMeltedUsers.js');
-var canvasUser = { id: 1734,
-       name: 'John Rauschenberg',
-       sortable_name: 'Rauschenberg, John',
-       short_name: 'John Rauschenberg',
-       sis_user_id: '2016060102',
-       integration_id: null,
-       sis_login_id: 'john@crisistextline.org',
-       sis_import_id: null,
-       login_id: 'john@crisistextline.org' };
+var updateCanvas = require('../jobs/scheduling/helpers/updateCanvas.js');
+var WiWUsers = require('../sample_data/sampleData').usersResponse;
 
 describe('drop melted users', function() {
 
-    it('should find all courses in Canvas', function (done) {
-      dropMeltedUsers.canvas.scrapeCanvasCourses()
+    it('should find courses in Canvas', function (done) {
+      var resultIsLong = false;
+      updateCanvas.canvas.retrieveCourses()
       .then(function(result) {
         assert.equal(result[0].id, 1);
+        if (result.length >= 40) resultIsLong = true;
+        assert.equal(resultIsLong, true);
         done();
       });
     });
 
     it('should find melted users in Canvas', function (done) {
-      dropMeltedUsers.canvas.scrapeCanvasEnrollment(60, 'inactive')
+      var canvasUserID = 1734;
+      updateCanvas.canvas.retrieveEnrollment(60, 'inactive')
       .then(function(result) {
-        assert.equal(result[0].user_id, 1734);
+        assert.equal(result[0].user_id, canvasUserID);
         done();
       });
     });
 
     it('should delete the melted user and their shifts from When I Work', function (done) {
-      var result = dropMeltedUsers.deleteWiWUserAndShifts({login_id: 'john@crisistextline.org'});
-      assert.equal(result[0], 7889841);
-      done();
-    });
-
-    it('should email the melted user', function (done) {
-      var result = dropMeltedUsers.canvas.emailDroppedUser(canvasUser);
-      assert.equal(result.subject, 'Melted');
+      var WiWUserID = 7889841;
+      var result = dropMeltedUsers.deleteWiWUserAndShifts({login_id: 'john@crisistextline.org'}, WiWUsers);
+      assert.equal(result[0], WiWUserID);
       done();
     });
 

--- a/test/dropMeltedUsers.js
+++ b/test/dropMeltedUsers.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var dropMeltedUsers = require('../jobs/scheduling/dropMeltedUsers.js');
+var canvasUser = { id: 1734,
+       name: 'John Rauschenberg',
+       sortable_name: 'Rauschenberg, John',
+       short_name: 'John Rauschenberg',
+       sis_user_id: '2016060102',
+       integration_id: null,
+       sis_login_id: 'john@crisistextline.org',
+       sis_import_id: null,
+       login_id: 'john@crisistextline.org' };
+
+describe('drop melted users', function() {
+
+    it('should find all courses in Canvas', function (done) {
+      dropMeltedUsers.canvas.scrapeCanvasCourses()
+      .then(function(result) {
+        assert.equal(result[0].id, 1);
+        done();
+      });
+    });
+
+    it('should find melted users in Canvas', function (done) {
+      dropMeltedUsers.canvas.scrapeCanvasEnrollment(60, 'inactive')
+      .then(function(result) {
+        assert.equal(result[0].user_id, 1734);
+        done();
+      });
+    });
+
+    it('should delete the melted user and their shifts from When I Work', function (done) {
+      var result = dropMeltedUsers.deleteWiWUserAndShifts({login_id: 'john@crisistextline.org'});
+      assert.equal(result[0], 7889841);
+      done();
+    });
+
+    it('should email the melted user', function (done) {
+      var result = dropMeltedUsers.canvas.emailDroppedUser(canvasUser);
+      assert.equal(result.subject, 'Melted');
+      done();
+    });
+
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -21,3 +21,4 @@ var notifyMoreShifts = require('./notifyMoreShifts.js');
 var timeOffRequests = require('./timeOffRequests');
 var recurShifts = require('./recurShifts.js');
 var updateCanvas = require('./updateCanvas');
+var dropMeltedUsers = require('./dropMeltedUsers');


### PR DESCRIPTION
#### What's this PR do?
It checks for users who have been marked by trainers in Canvas as "deactivated," finds them in WiW, and deletes them and their shifts.
#### Where should the reviewer start?
jobs/scheduling/dropMeltedUsers
#### How should this be manually tested?
npm test, and/or:
1. Create a fake Canvas user.
2. Enroll the user in a course.
3. Select "deactivate user" for your user in the list of students in the course.
4. Create a user with the same email address in WiW.
5. Sign that user up for a shift or two in WiW.
6. Run dropMeltedUsers with node (including the appropriate CONFIG and KEYS variables as needed to help it run). Alternatively, use runJobs, but only set it to run dropMeltedUsers.
7. Make sure the user's WiW account no longer exists and their shifts no longer belong to them.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-130](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-130), [INT-131](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-131), [INT-132](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-132)
#### Questions:
