### PR TITLE
Refactored NotifyMoreShifts to check 15 days out for shifts the user …

### DIFF
--- a/jobs/scheduling/NotifyMoreShifts.js
+++ b/jobs/scheduling/NotifyMoreShifts.js
@@ -17,7 +17,7 @@ notifyMoreShifts();
 function notifyMoreShifts() {
   var result;
   var query = {
-    end: '+' + CONFIG.time_interval.one_week + ' days',
+    end: '+' + CONFIG.time_interval.days_of_open_shift_display + ' days',
     location_id: CONFIG.locationID.regular_shifts
   };
 
@@ -59,6 +59,12 @@ function objectHasOwnKeys(obj) {
   return numberOfKeys;
 }
 
+function parseShiftStartTime(shiftStartTime) {
+  //slicing the shift time for just the day of week and start time;
+  //we want to match those rather than date to see if a shift is recurring
+  return shiftStartTime.slice(0,3) + shiftStartTime.slice(16);
+}
+
 function tallyUserShifts(shifts) {
   var users = {};
 
@@ -66,9 +72,14 @@ function tallyUserShifts(shifts) {
     if (typeof users[shift.user_id] == 'undefined') {
       users[shift.user_id] = [];
     }
-    users[shift.user_id].push(shift.start_time);
+    //filter here to ensure that we're not counting one weekly shift 
+    //that recurs twice during the 15 day window as two weekly shifts
+    if (users[shift.user_id].every(function(shiftTime) {
+      return parseShiftStartTime(shiftTime) !== parseShiftStartTime(shift.start_time);
+    })) {
+      users[shift.user_id].push(shift.start_time);
+    }
   });
-
   return users; 
 }
 

--- a/test/notifyMoreShifts.js
+++ b/test/notifyMoreShifts.js
@@ -15,6 +15,13 @@ describe('Notify More Shifts', function() {
 
     });
 
+    it('does not count one weekly shift that recurs twice during the 15 day window as two weekly shifts', function (done) {
+
+      assert(!usersToNotify['5674724']);
+      done();
+
+    });
+
     it('creates correct post object for users not yet notified', function (done) {
     
       var expectedBatchPosts = [ { method: 'PUT', url: '/2/users/5674723', params: { notes: '{"two_shift_notification":true}' } } ];


### PR DESCRIPTION
#### What's this PR do?
Responds to trainer wishes that we check 15 days in the future (rather than the current 7) for shifts that new WiW users have signed up for. It also makes sure that we aren't counting a single weekly shift that recurs twice during the 15-day period as two weekly shifts. It will fix the problem where it can take a week or more for trainees and trainers to get the notification that first shifts have been signed up for, as well as the check mark in Canvas.
#### Where should the reviewer start?
NotifyMoreShifts.js
#### How should this be manually tested?
npm test, or:
1. Sign up for a SINGLE recurring weekly shift in the test environment on WiW that will recur twice in the next 15 days.
2. Modify NotifyMoreShifts to use the test location instead of regular_shifts. Also add in CONFIG and KEYS variables as needed.
3. Add a console.log between line 81 and 82 of NotifyMoreShfits to log out users.
4. Node NotifyMoreShifts.
5. Confirm that your user ID only has one shift in its array.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-231
](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-231)#### Questions:

…has signed up for, but also make sure that it doesn't count one weekly shift recurring twice as two shifts.