### PR TITLE
hotfix for not returning objects in response

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -32,7 +32,7 @@ function recurNewlyCreatedShifts() {
                     "end": endDateToRetrieveShifts
                   };
 
-  WhenIWork.get('shifts?include_objects=false', postData, function(response) {
+  WhenIWork.get('shifts', postData, function(response) {
     var allShifts = response.shifts;
     if (typeof allShifts !== 'object') {
       CONSOLE_WITH_TIME('NO SHIFTS RETURNED.');


### PR DESCRIPTION
#### What's this PR do?
Previously, we removed relevant objects from being returned in the response for a `/get` request to WhenIWork. 

This broke things in this job, which caused our app to restart a bajillion times, which caused us to hit rate limits in Canvas and GTW. 

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Questions:

