### PR TITLE
Update Canvas when CCs attend first shift

### DIFF
--- a/config.js
+++ b/config.js
@@ -72,14 +72,20 @@ CONFIG.wiwAccountID = {
   supervisors: 622060,
 };
 
+CONFIG.canvas = {
+  // String represents the name of the assignment in Canvas gradebook.
+  assignments: {
+    attendedFirstShift: 'Attend First Shift',
+    scheduledShifts: 'Schedule Your Shifts',
+    platformReady: 'Platform Ready!',
+    webinarAttended: 'Attend An Observation',
+  },
+};
+
 //used in AttendanceSync.js to check whether trainees attended a GTW webinar for a minimum of 90 minutes = 5400 seconds
 CONFIG.GTW_attendance_minimum = 5400;
 //used in AttendanceSync.js to set the hour range over which we query GTW sessions
 CONFIG.GTW_time_range_query = 72;
-//Name of the graduation assignment in Canvas
-CONFIG.Canvas_graduation = 'Platform Ready!';
-//Name of the GoToWebinar assignment in Canvas
-CONFIG.Canvas_webinar = 'Attend An Observation';
 
 CONFIG.time_interval = {
   // runs every day at 5am

--- a/jobs/scheduling/AttendanceSync.js
+++ b/jobs/scheduling/AttendanceSync.js
@@ -150,7 +150,7 @@ function findCanvasUserByName(GTWUser){
 
 //scrapes canvas for user by name, course and assignment id's
 function queryForCanvasCoursesAndAssignments(userID){
-  var assignmentQuery = {search_term: CONFIG.Canvas_webinar},
+  var assignmentQuery = {search_term: CONFIG.canvas.assignments.webinarAttended},
   Eurl = 'https://crisistextline.instructure.com/api/v1/users/'+userID+'/enrollments';
       //scrape for user's enrollments in order to get course ID
   canvas.scrapeCanvasEnroll(Eurl)

--- a/jobs/scheduling/helpers/updateCanvas.js
+++ b/jobs/scheduling/helpers/updateCanvas.js
@@ -1,11 +1,13 @@
-var Request = require('request-promise');
-var options = {
+'use strict';
+
+const Request = require('request-promise');
+const options = {
   headers: {
     Authorization: KEYS.canvas.api_key,
     'User-Agent': 'Request-Promise',
   }
 };
-var canvas = {};
+const canvas = {};
 
 //finds all assignments in a specific canvas course
 canvas.scrapeCanvasAssignments = function(courseID, filter){
@@ -23,7 +25,7 @@ canvas.scrapeCanvasAssignments = function(courseID, filter){
 
 };
 
-//finds all canvas users with a specific name
+//finds all canvas users with a specific email address
 canvas.scrapeCanvasUsers = function(email) {
 
   options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/users?search_term=' + email;
@@ -104,9 +106,9 @@ canvas.updateUserGrade = function(user, course, assignment, grade) {
 
   function callback(error, response, body){
     if(!error && response.statusCode == 200){
-      CONSOLE_WITH_TIME('Canvas update succeeded for user ID ', user);
+      CONSOLE_WITH_TIME(`Canvas update succeeded for user ID ${user}`);
     } else {
-      CONSOLE_WITH_TIME("Canvas error message: ", response, response.statusCode);
+      CONSOLE_WITH_TIME(`Canvas error message: ${response} ${response.statusCode}`);
     }
   }
 
@@ -114,10 +116,10 @@ canvas.updateUserGrade = function(user, course, assignment, grade) {
 
 };
 
-findWiWUserInCanvas = function(email) {
+const findWiWUserInCanvas = function(email) {
   //collects canvas user ID, courseID, and assignment ID based on the WiW
   //user ID, then calls the update grade function, which needs all three.
-  var userID, courseID, assignmentID;
+  var userID, courseID;
 
   canvas.scrapeCanvasUsers(email)
   .then(function(users) {
@@ -137,14 +139,14 @@ findWiWUserInCanvas = function(email) {
     return courses[0].course_id;
   })
   .then(function(courseID) {
-    return canvas.scrapeCanvasAssignments(courseID, 'Schedule Your Shifts');
+    return canvas.scrapeCanvasAssignments(courseID, CONFIG.canvas.assignments.scheduledShifts);
   })
   .then(function(assignment) {
     if (assignment.length === 0) throw "No 'Schedule Your Shifts' assignment for that user was found in Canvas.";
     return canvas.updateUserGrade(userID, courseID, assignment[0].id, 'pass');
   })
   .catch(function(err) {
-    CONSOLE_WITH_TIME("Finding the user " + name + " with email " + email + " in Canvas failed: ", err);
+    CONSOLE_WITH_TIME(`Finding the user ${name} with email ${email} in Canvas failed: ${err}`);
   });
 
 };

--- a/jobs/training/pollCanvasForGraduatedUsersThenCreatePlatformAccount.js
+++ b/jobs/training/pollCanvasForGraduatedUsersThenCreatePlatformAccount.js
@@ -33,7 +33,7 @@ function pollCanvasForGraduatedUsersThenCreatePlatformAccount() {
         request('courses/' + course.id + '/assignments', 'GET')
           .then(function (assignments) {
             return assignments.filter(function (assignment) {
-              return assignment.name.indexOf(CONFIG.Canvas_graduation) >= 0;
+              return assignment.name.indexOf(CONFIG.canvas.assignments.platformReady) >= 0;
             });
           })
           .then(function (assignments) {

--- a/www/app.js
+++ b/www/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 //REQUIRING KEYS BEFORE CONFIG BECAUSE CONFIG DEPENDS ON KEYS
 global.KEYS = require('../keys.js');
 global.CONFIG = require('../config');
@@ -9,15 +11,15 @@ else {
   require('newrelic');
 }
 
-var express = require('express');
-var path = require('path');
-var favicon = require('static-favicon');
-var logger = require('morgan');
-var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
-var debug = require('debug')('my-application');
+const express = require('express');
+const path = require('path');
+const favicon = require('static-favicon');
+const logger = require('morgan');
+const cookieParser = require('cookie-parser');
+const bodyParser = require('body-parser');
+const debug = require('debug')('my-application');
 
-var app = express();
+const app = express();
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -30,11 +32,12 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/scheduling', require('./scheduling').router)
+app.use('/scheduling', require('./scheduling').router);
+app.use('/canvas', require('./canvas').router);
 
 /// catch 404 and forwarding to error handler
 app.use(function(req, res, next) {
-  var err = new Error('Not Found');
+  const err = new Error('Not Found');
   err.status = 404;
   next(err);
 });

--- a/www/canvas/index.js
+++ b/www/canvas/index.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const express = require('express');
+const canvas = require(CONFIG.root_dir + '/jobs/scheduling/helpers/updateCanvas.js').canvas;
+const stathat = require(CONFIG.root_dir + '/lib/stathat');
+const router = express.Router();
+
+const mandrill = require('mandrill-api/mandrill');
+const mandrillClient = new mandrill.Mandrill(KEYS.mandrill.api_key);
+
+router.put('/firstShift', function (req, res) {
+  const assignment = CONFIG.canvas.assignments.attendedFirstShift;
+  const user = req.body.user;
+  let promiseUserID;
+  let promiseCourseID;
+  let promiseAssignmentID;
+
+  // request canvas user with this email address and find their userId
+  promiseUserID = canvas.scrapeCanvasUsers(user.email)
+  .then((users) => {
+    if (users.length === 0) throw 'No user was found in Canvas for that email.';
+    return users[0].id;
+  }).catch(err => {
+    const subject = `Error finding user with email ${user.email} in Canvas`;
+    logErrEmailHeather(subject, err, user, assignment);
+  });
+
+  // request courses and find correct courseId;
+  promiseCourseID = promiseUserID.then((userID) => {
+    return canvas.scrapeCanvasEnrollment(userID);
+    })
+    .then((courses) => {
+    courses = courses.filter((course) => {
+      return course.enrollment_state === 'active';
+    });
+    if (courses.length === 0) throw 'No active courses for that user were found in Canvas.';
+    return courses[0].course_id;
+  }).catch(err => 
+    CONSOLE_WITH_TIME(`Error finding active course for ${user.email}: ${err}`)
+  );
+
+  // request assignments for course and find correct assignment
+  promiseAssignmentID = promiseCourseID.then((courseID) => {
+    return canvas.scrapeCanvasAssignments(courseID, assignment);
+  })
+  .then(assignments => {
+    if (assignments.length === 0) throw `Canvas returned 0 assignments`;
+    return assignments[0].id;
+  }).catch(err => {
+    const subject = `Error finding ${assignment} in course found for ${user.email}`;
+    logErrEmailHeather(subject, err, user, assignment);
+  });
+
+
+  Promise.all([promiseUserID, promiseCourseID, promiseAssignmentID])
+  .then(responses => {
+    // responses is [userID, courseID, assignmentID] so we spread it
+    return canvas.updateUserGrade(...responses, 'complete');
+  })
+  .then(() => res.send(`Successfully updated ${user.email}`))
+  .catch((err) => {
+    const message = `Updating ${assignment} for ${user.email} in Canvas failed: ${err}`;
+    CONSOLE_WITH_TIME(message);
+    res.status(500).send(message);
+  });
+
+  stathat.increment('Canvas - Attend First Shift', 1);
+});
+
+function logErrEmailHeather (subject, err, user, assignment) {
+  CONSOLE_WITH_TIME(`${subject}: ${err}`);
+
+  const message = {
+    subject: subject,
+    text: `Hi Heather, Due to the specified error in the subject platform user:` +
+      `${JSON.stringify(user)} was not able to be given credit for ${assignment}`,
+    from_email: 'support@crisistextline.org',
+    from_name: 'Crisis Text Line',
+    to: [{
+        email: 'heather@crisistextline.org',
+        name: 'Heather',
+        type: 'to'
+    }]
+  };
+
+  mandrillClient.messages.send({message: message, key: 'canvas_user_not_found'}, function (res) {
+      CONSOLE_WITH_TIME(res);
+  });
+
+}
+
+module.exports = {router};


### PR DESCRIPTION
**What's this PR do?**
Create a route for the platform to update canvas when a user attends their shift

**How should this be manually tested?**
Already tested with TC, but we can test again ->
Can test by using a real canvas email to Postman put to /canvas/firstShift with a body that contains {"user": {"name":"Whoever you want","email":"realCanvasAccount@crisistextline.org"}} and see if the user with that email address had their assignment updated.

**Any background context you want to provide?**
This is a remake of PR https://github.com/CrisisTextLine/Elmer/pull/161

**What are the relevant tickets?**
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-236
