### PR TITLE
Refactored notify more shifts email and function to reflect that we'r…

### DIFF
--- a/api_wiw/WiWCCApi.js
+++ b/api_wiw/WiWCCApi.js
@@ -1,6 +1,6 @@
 'use strict';
 
 const WhenIWork = require('wheniwork-unofficial');
-const api = new WhenIWork(KEYS.wheniwork.api_key, KEYS.wheniwork.username, KEYS.wheniwork.password);
+const api = new WhenIWork(KEYS.wheniwork.api_key, KEYS.wheniwork.username, KEYS.wheniwork.password, 'Crisis Text Line');
 
 module.exports = api;

--- a/config.js
+++ b/config.js
@@ -87,6 +87,10 @@ CONFIG.GTW_attendance_minimum = 5400;
 //used in AttendanceSync.js to set the hour range over which we query GTW sessions
 CONFIG.GTW_time_range_query = 72;
 
+CONFIG.WiWUserNotes = {
+  shiftNotification: 'firstShiftNotification'
+};
+
 CONFIG.time_interval = {
   // runs every day at 5am
   gtw_attendance_sync_with_canvas:'0 0 5 * * *',

--- a/email_templates/composeNotifyMoreShifts.js
+++ b/email_templates/composeNotifyMoreShifts.js
@@ -7,14 +7,12 @@ const composeSupTiles = require('./createSupervisorTiles.js');
 function composeEmail (user, shiftToSup) {
   const body = composeSupTiles(user.shifts[0], shiftToSup);
 
-  const shifts = user.shifts.map((shift) => {
-      return moment(shift, dateFormat).format('dddd, MMMM Do YYYY, h:mm a') + ' ET';
-    }).join('</p> <p>');
+  const shift = moment(user.shifts[0], dateFormat).format('dddd, MMMM Do YYYY, h:mm a') + ' ET';
 
   const intro = `<div>` +
     `<p> Hey ${user.firstName}! </p>` +
-    `<p> Woohoo! You signed up for ${user.shifts.length} weekly shifts. We've got you down for: </p>` +
-    `<p>${shifts}</p>` +
+    `<p> Woohoo! You signed up for your first shift. We've got you down for: </p>` +
+    `<p>${shift}</p>` +
     `<p> As promised, you'll be in good hands. Here are the supervisors who will have your back on your first shift: </p>` +
     `<div style='display: flex; text-align:center'>`;
 

--- a/jobs/scheduling/helpers/notifyUserBookedShift.js
+++ b/jobs/scheduling/helpers/notifyUserBookedShift.js
@@ -24,7 +24,9 @@ function filterUsersToObject (users){
     var created = moment(new Date(user.created_at));
     // Only includes users who have already received the two_shift_notification note
     // or are at least 'days_of_open_shift_display' old and will never get that user note
-    if (/two_shift_notification/.test(user.notes) || moment().diff(created, 'days') >= CONFIG.time_interval.days_until_older_user) usersObj[user.id] = user;
+    var shiftNotification = new RegExp(CONFIG.WiWUserNotes.shiftNotification,`g`);
+    //the first part of the or statement will be unncessary below once we go through and change all user notes
+    if (/two_shift_notification/.test(user.notes) || shiftNotification.test(user.notes) || moment().diff(created, 'days') >= CONFIG.time_interval.days_until_older_user) usersObj[user.id] = user;
   });
   return usersObj;
 }

--- a/jobs/scheduling/helpers/updateCanvas.js
+++ b/jobs/scheduling/helpers/updateCanvas.js
@@ -123,7 +123,7 @@ const findWiWUserInCanvas = function(email) {
 
   canvas.scrapeCanvasUsers(email)
   .then(function(users) {
-    if (users.length === 0) throw 'No combination of that name and email was found in Canvas.';
+    if (users.length === 0) throw 'That email was not found in Canvas.';
     userID = users[0].id;
     return users[0].id;
   })
@@ -146,7 +146,7 @@ const findWiWUserInCanvas = function(email) {
     return canvas.updateUserGrade(userID, courseID, assignment[0].id, 'pass');
   })
   .catch(function(err) {
-    CONSOLE_WITH_TIME(`Finding the user ${name} with email ${email} in Canvas failed: ${err}`);
+    CONSOLE_WITH_TIME(`Finding the user with the email ${email} in Canvas failed: ${err}`);
   });
 
 };

--- a/test/notifyMoreShifts.js
+++ b/test/notifyMoreShifts.js
@@ -4,9 +4,9 @@ var fs = require('fs');
 
 describe('Notify More Shifts', function() {
   describe('finds users to notify and', function() {
-    var twoShiftNotificationResult = notifyMoreShiftsObj.notifyMoreShifts();
-    var usersToNotify = twoShiftNotificationResult.usersBeingNotified;
-    var batchPosts = twoShiftNotificationResult.updateUserNotes;
+    var notificationResult = notifyMoreShiftsObj.notifyMoreShifts();
+    var usersToNotify = notificationResult.usersBeingNotified;
+    var batchPosts = notificationResult.updateUserNotes;
 
     it('creates correct users object for users not yet notified', function (done) {
 
@@ -15,21 +15,20 @@ describe('Notify More Shifts', function() {
 
     });
 
-    it('does not count one weekly shift that recurs twice during the 15 day window as two weekly shifts', function (done) {
-
-      assert(!usersToNotify['5674724']);
-      done();
-
-    });
-
     it('creates correct post object for users not yet notified', function (done) {
     
-      var expectedBatchPosts = [ { method: 'PUT', url: '/2/users/5674723', params: { notes: '{"two_shift_notification":true}' } } ];
+      var expectedBatchPosts = [ { method: 'PUT',
+        url: '/2/users/5674723',
+        params: { notes: '{"firstShiftNotification":true}' } },
+      { method: 'PUT',
+        url: '/2/users/5674724',
+        params: { notes: '{"two_shift_notification":true,"original_owner":5674723,"parent_shift":277119256,"firstShiftNotification":true}' } } ];
       assert.deepEqual(batchPosts, expectedBatchPosts);
       done();
 
     });
   });
+  
   it('creates correct mandrill messages', function (done){
 
     var sampleUser = {
@@ -47,7 +46,7 @@ describe('Notify More Shifts', function() {
           type: 'to'
       }];
 
-    var expectedHTML = `<div><p> Hey Someone! </p><p> Woohoo! You signed up for 2 weekly shifts. We've got you down for: </p><p>Thursday, January 28th 2016, 2:00 pm ET</p> <p>Monday, February 1st 2016, 2:00 pm ET</p><p> As promised, you'll be in good hands. Here are the supervisors who will have your back on your first shift: </p><div style='display: flex; text-align:center'><div style='padding: 10px; border:1px solid black; width:160px; margin: 10px;'>Lindsay Martin <br> <img src=https://s.gravatar.com/avatar/35a7cf2185f668864530cb0610b8372e?s=200 alt='Lindsay Martin' height='150' width='150'></div><div style='padding: 10px; border:1px solid black; width:160px; margin: 10px;'>Garrett Shotwell <br> <img src=https://s.gravatar.com/avatar/d98b20d5c27e6ca6042440bf43dbd59b?s=200 alt='Garrett Shotwell' height='150' width='150'></div></div><p> Our supervisors are amazeballs. They're also human beings who take vacations and get sick - if your super above isn’t online for your shift, don't fret. You’ll be in good hands with someone else on our team. Here are a few pro tips for the platform: </p><ul><li>Your supervisor's name is on the upper left corner of your screen (click it and say hello!)</li><li>Enter your status under your name (suggestion: "First Shift" - or some funky version of this, so your fellow crisis counselors know to say hi!)</li><li>Only take 1 conversation at a time</li><li>NEVER feel like you are alone, your peers and supervisors are there to help!</li><li>Say hi to everyone in the Global Chat let them know you are new - join the convo (it's a fun crew!)</li><li>If you need to make any changes to your schedule, or aren't able to make your first shift please visit CTL Online and click on "Shift Scheduling".</li></ul> <p> Taking your first shift is the last step in becoming a bona fide Crisis Counselor! You got this!</p><p> Enjoy your first shift, </p> <p> The Crisis Text Line Training Team </p></div>`;
+    var expectedHTML = `<div><p> Hey Someone! </p><p> Woohoo! You signed up for your first shift. We've got you down for: </p><p>Thursday, January 28th 2016, 2:00 pm ET</p><p> As promised, you'll be in good hands. Here are the supervisors who will have your back on your first shift: </p><div style='display: flex; text-align:center'><div style='padding: 10px; border:1px solid black; width:160px; margin: 10px;'>Lindsay Martin <br> <img src=https://s.gravatar.com/avatar/35a7cf2185f668864530cb0610b8372e?s=200 alt='Lindsay Martin' height='150' width='150'></div><div style='padding: 10px; border:1px solid black; width:160px; margin: 10px;'>Garrett Shotwell <br> <img src=https://s.gravatar.com/avatar/d98b20d5c27e6ca6042440bf43dbd59b?s=200 alt='Garrett Shotwell' height='150' width='150'></div></div><p> Our supervisors are amazeballs. They're also human beings who take vacations and get sick - if your super above isn’t online for your shift, don't fret. You’ll be in good hands with someone else on our team. Here are a few pro tips for the platform: </p><ul><li>Your supervisor's name is on the upper left corner of your screen (click it and say hello!)</li><li>Enter your status under your name (suggestion: "First Shift" - or some funky version of this, so your fellow crisis counselors know to say hi!)</li><li>Only take 1 conversation at a time</li><li>NEVER feel like you are alone, your peers and supervisors are there to help!</li><li>Say hi to everyone in the Global Chat let them know you are new - join the convo (it's a fun crew!)</li><li>If you need to make any changes to your schedule, or aren't able to make your first shift please visit CTL Online and click on "Shift Scheduling".</li></ul> <p> Taking your first shift is the last step in becoming a bona fide Crisis Counselor! You got this!</p><p> Enjoy your first shift, </p> <p> The Crisis Text Line Training Team </p></div>`;
 
     fs.readFile('./test/helpers/supervisorSampleData/sortedSupersToShifts.json', 'utf-8', function(err, shiftToSup) {
       if (err) console.log('FS ERROR', err);


### PR DESCRIPTION
#### What's this PR do?
Adjusts NotifyMoreShifts and the associated composeNotifyMoreShifts email template to reflect desired trainer changes. Specifically, we want to move from only giving trainees credit for scheduling two weekly shifts to giving them credit for scheduling at least one shift of any type.
#### Where should the reviewer start?
jobs/scheduling/NotifyMoreShifts and email_templates/composeNotifyMoreShifts.
#### How should this be manually tested?
Npm test, node, or create a new Canvas user, enroll in a cohort, create a WiW account with the same email address, sign up for a shift in WiW, and test if you get an email.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-260](https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-260)
#### Questions:

…e notifying users when they've booked any shift whatsoever, as opposed to two regular shifts.