### PR TITLE
fix shift deletion

### DIFF
--- a/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
+++ b/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
@@ -30,12 +30,12 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
   var query = {
     user_id: req.query.userID,
     start: '-1 day',
-    end: '+50 years',
+    end: '+6 years',
     unpublished: true,
     location_id: [ CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts ]
   };
 
-  whenIWorkAPI.get('shifts?include_objects=false', query, function (data) {
+  whenIWorkAPI.get('shifts', query, function (data) {
     var parentShiftID;
     var shift;
     var batchPayload = [];


### PR DESCRIPTION
#### What's this PR do?
Fixes shift deletion. Adding the `include_objects=false` call to the get request here broke shift deletion. 

#### Where should the reviewer start?
#### How should this be manually tested?
Manually tested by running the functionality in the weekly shifts environment on my local. 
#### Any background context you want to provide?
#### What are the relevant tickets?
Closes https://admin.crisistextline.org/jira/browse/INT-270
#### Questions:

