### PR TITLE
fix recur shifts by removing "include_objects=false" flag

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -145,7 +145,7 @@ function recurNewlyCreatedShifts() {
             "unpublished": true
           };
           // Getting all shifts created in the timeframe defined above in 'postData' that are unpublished.
-          WhenIWork.get('shifts?include_objects=false', postData, function(response) {
+          WhenIWork.get('shifts', postData, function(response) {
             if (!response.shifts) CONSOLE_WITH_TIME("[Error 146] RecurShifts response missing .shifts", response);
             else {
               var unpublishedShifts = response.shifts.filter(function(shift) {
@@ -180,7 +180,7 @@ function recurNewlyCreatedShifts() {
             "unpublished": true
           };
 
-          WhenIWork.get('shifts?include_objects=false', postData, function(response) {
+          WhenIWork.get('shifts', postData, function(response) {
             if (!response.shifts) CONSOLE_WITH_TIME("[Error 181] RecurShifts response missing .shifts", response);
             else {
               var unpublishedShifts = response.shifts.filter(function(shift) {
@@ -234,13 +234,13 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
     end: nextWeekShiftEndTime
   };
 
-  WhenIWork.get('shifts?include_objects=false', openShiftQuery, function(response) {
+  WhenIWork.get('shifts', openShiftQuery, function(response) {
     var openShifts = response.shifts;
     if (typeof openShifts !== 'object' || openShifts.length === 0) {
       CONSOLE_WITH_TIME('NO OPEN SHIFTS RETURNED TO DECREMENT.');
       CONSOLE_WITH_TIME('===================');
       CONSOLE_WITH_TIME('RESPONSE: ' + response);
-      CONSOLE_WITH_TIME('POST: ' + postData);
+      CONSOLE_WITH_TIME('GET REQUEST PARAMS: ' + openShiftQuery);
       return;
     }
 


### PR DESCRIPTION
#### What's this PR do?
Once again, the `include_objects=false` flag was breaking jobs. 

This fixes the recurrence job. 

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/browse/INT-275
#### Questions:

