### PR TITLE
make CONSOLE_WITH_TIME abide by timezones in logs

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ global.CONSOLE_WITH_TIME = function(){
       message+=arguments[key]+ " ";
     }
   }
-  console.log('[' + new Date() + ']', message.slice(0, message.length-1));
+  console.log('[' + moment().format('llll Z') + ']', message.slice(0, message.length-1));
 };
 
 /**


### PR DESCRIPTION
#### What's this PR do?
Allows us to more easily debug timing messiness on prod by making our CONSOLE_WITH_TIME call log in EST. 

#### Where should the reviewer start?
#### How should this be manually tested?
Tested locally by running `node runJobs.js`. 
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Questions:

