### PR TITLE
Create route for typeform submissions and post to Canvas submissions

### DIFF
--- a/jobs/scheduling/helpers/notifyUserBookedShift.js
+++ b/jobs/scheduling/helpers/notifyUserBookedShift.js
@@ -48,7 +48,7 @@ function mandrillEachUser (shifts, userIdToInfo, shiftsToSup){
     var message = {
       subject: "You're signed up for a new CTL shift!",
       html: contents,
-      from_email: 'supervisors@crisistextline.org',
+      from_email: 'support@crisistextline.org',
       from_name: 'Crisis Text Line',
       to: [{
           email: email,

--- a/jobs/scheduling/helpers/updateCanvas.js
+++ b/jobs/scheduling/helpers/updateCanvas.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Request = require('request-promise');
+const request = require('request-promise');
 const options = {
   headers: {
     Authorization: KEYS.canvas.api_key,
@@ -14,7 +14,7 @@ canvas.scrapeCanvasAssignments = function(courseID, filter){
 
   options.url = 'https://crisistextline.instructure.com/api/v1/courses/' + courseID + '/assignments?search_term=' + filter;
 
-  return Request(options)
+  return request(options)
   .then(function(response){
     response = JSON.parse(response);
     return response;
@@ -30,7 +30,7 @@ canvas.scrapeCanvasUsers = function(email) {
 
   options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/users?search_term=' + email;
 
-  return Request(options)
+  return request(options)
   .then(function(response){
     response = JSON.parse(response);
     if (Array.isArray(response) && response.length === 0) throw 'No user with that email found.';
@@ -46,7 +46,7 @@ canvas.retrieveCourses = function() {
 
   options.url = 'https://crisistextline.instructure.com/api/v1/accounts/1/courses?per_page=1000';
 
-  return Request(options)
+  return request(options)
   .then(function(response){
     response = JSON.parse(response);
     if (Array.isArray(response) && response.length === 0) throw 'No courses found.';
@@ -63,7 +63,7 @@ canvas.retrieveEnrollment = function(courseID, enrollmentState) {
 
   options.url = 'https://crisistextline.instructure.com/api/v1/courses/' + courseID + '/enrollments?state[]=' + enrollmentState;
 
-  return Request(options)
+  return request(options)
   .then(function(response){
     response = JSON.parse(response);
     return response;
@@ -79,7 +79,7 @@ canvas.scrapeCanvasEnrollment = function(userID) {
 
   options.url = 'https://crisistextline.instructure.com/api/v1/users/' + userID + '/enrollments';
 
-  return Request(options)
+  return request(options)
   .then(function(response){
     response = JSON.parse(response);
     return response;
@@ -104,16 +104,95 @@ canvas.updateUserGrade = function(user, course, assignment, grade) {
     }
   };
 
-  function callback(error, response, body){
-    if(!error && response.statusCode == 200){
-      CONSOLE_WITH_TIME(`Canvas update succeeded for user ID ${user}`);
+  function callback(error, response){
+    if(!error && response.statusCode === 200){
+      CONSOLE_WITH_TIME(`Canvas grading succeeded for user ID ${user}`);
     } else {
+      CONSOLE_WITH_TIME(`Canvas submission failed for user ID ${user}`);
       CONSOLE_WITH_TIME(`Canvas error message: ${response} ${response.statusCode}`);
     }
   }
 
-  return Request.put(updateOptions, callback);
+  return request.put(updateOptions, callback);
 
+};
+
+canvas.submitAssignment = function(user, course, assignment, submissionHTML) {
+  //Submits assignment on users behalf
+  var url = `https://crisistextline.instructure.com/api/v1/courses/${course}/assignments/${assignment}/submissions?as_user_id=${user}`;
+  var updateOptions = {
+    url: url,
+    json: true,
+    headers: {
+      Authorization: KEYS.canvas.api_key
+    },
+    body: {
+      submission: {
+        submission_type: 'online_text_entry',
+        body: submissionHTML 
+      }
+    }
+  };
+
+  function callback(error, response){
+    if(!error && response.statusCode === 201){
+      CONSOLE_WITH_TIME(`Canvas submission succeeded for user ID ${user}`);
+    } else {
+      CONSOLE_WITH_TIME(`Canvas submission failed for user ID ${user}`);
+      CONSOLE_WITH_TIME(`Canvas error message: ${response} ${response.statusCode}`);
+    }
+  }
+
+  return request.post(updateOptions, callback);
+
+};
+
+canvas.retrieveUserCourseAssignmentIds = function(userEmail, assignment, errFunc){
+  let promiseUserID;
+  let promiseCourseID;
+  let promiseAssignmentID;
+
+  // request canvas user with this email address and find their userId
+  promiseUserID = canvas.scrapeCanvasUsers(userEmail)
+    .then((users) => {
+      if (users.length === 0) throw 'No user was found in Canvas for that email.';
+      return users[0].id;
+    }).catch(err => {
+      const subject = `Error finding user with email ${userEmail} in Canvas`;
+      errFunc(subject, err);
+    });
+
+  let userCanvasID; 
+  // request courses and find correct courseId;
+  promiseCourseID = promiseUserID
+    .then((userID) => {
+      userCanvasID = userID;
+      return canvas.scrapeCanvasEnrollment(userID);
+    })
+    .then((courses) => {
+      courses = courses.filter((course) => {
+        return course.enrollment_state === 'active';
+      });
+      if (courses.length === 0) throw 'No active courses for user ${userCanvasID} were found in Canvas.';
+      return courses[0].course_id;
+    }).catch(err => {
+      const subject = `Error finding active course for ${userEmail} in Canvas`;
+      errFunc(subject, err);
+    });
+
+  // request assignments for course and find correct assignment
+  promiseAssignmentID = promiseCourseID.then((courseID) => {
+    return canvas.scrapeCanvasAssignments(courseID, assignment);
+    })
+    .then(assignments => {
+      if (assignments.length === 0) throw `Canvas returned 0 assignments`;
+      return assignments[0].id;
+    }).catch(err => {
+      const subject = `Error finding ${assignment} in course found for ${userEmail}`;
+      errFunc(subject, err);
+    });
+
+  return Promise.all([promiseUserID, promiseCourseID, promiseAssignmentID]);
 };
 
 const findWiWUserInCanvas = function(email) {
@@ -122,7 +201,6 @@ const findWiWUserInCanvas = function(email) {
   var userID;
   var courseID;
   var name;
-  var email;
 
   canvas.scrapeCanvasUsers(email)
   .then(function(users) {

--- a/test/helpers/checkHTTPResponses.js
+++ b/test/helpers/checkHTTPResponses.js
@@ -8,7 +8,7 @@
 const moment = require('moment-timezone');
 const fs = require('fs');
 
-global.KEYS = require('../../keys.js.config');
+global.KEYS = require('../../keys.js.default');
 global.CONFIG = require('../../config.js');
 const WhenIWork = CONFIG.WhenIWork;
 const dateFormat = 'YYYY-MM-DD HH:mm:ss';

--- a/www/canvas/helpers.js
+++ b/www/canvas/helpers.js
@@ -1,0 +1,36 @@
+'use strict';
+
+function extractEmailAndFormatSubmission (formResponse) {
+  const emailWithSubmission = {};
+  const answers = {};
+
+  formResponse.answers.forEach(answer => {
+    if (answer.type === 'email') emailWithSubmission.email = answer.email;
+
+    if (answer.type === 'boolean') {
+      if(answer[answer.type]) answers[answer.field.id] = 'Yes';
+      else answers[answer.field.id] = 'No';
+    } else {
+      answers[answer.field.id] = answer[answer.type];
+    }
+  });
+
+  let qWithBolding = '';
+
+  const pairedQtoA = formResponse.definition.fields
+                      .sort((a,b) => a.id-b.id)
+                      .map(formatHTML);
+
+  function formatHTML (question, idx) {
+    qWithBolding = question.title.replace('Texter: ', '<b>Texter: </b>');
+    return `<h1>${idx}: ${qWithBolding}</h1>` +
+    `<h2><b>Crisis Counselor: </b>${answers[question.id]}</h2>`;
+  }
+  
+  emailWithSubmission.submissionHTML = `<p> ${pairedQtoA.join('</p><br><p>')} </p>`;
+
+  return emailWithSubmission;
+}
+
+
+module.exports = {extractEmailAndFormatSubmission};

--- a/www/canvas/index.js
+++ b/www/canvas/index.js
@@ -5,54 +5,18 @@ const canvas = require(CONFIG.root_dir + '/jobs/scheduling/helpers/updateCanvas.
 const stathat = require(CONFIG.root_dir + '/lib/stathat');
 const router = express.Router();
 
+const helpers = require(`${CONFIG.root_dir}/www/canvas/helpers.js`);
 const mandrill = require('mandrill-api/mandrill');
 const mandrillClient = new mandrill.Mandrill(KEYS.mandrill.api_key);
 
 router.put('/firstShift', function (req, res) {
   const assignment = CONFIG.canvas.assignments.attendedFirstShift;
   const user = req.body.user;
-  let promiseUserID;
-  let promiseCourseID;
-  let promiseAssignmentID;
 
-  // request canvas user with this email address and find their userId
-  promiseUserID = canvas.scrapeCanvasUsers(user.email)
-  .then((users) => {
-    if (users.length === 0) throw 'No user was found in Canvas for that email.';
-    return users[0].id;
-  }).catch(err => {
-    const subject = `Error finding user with email ${user.email} in Canvas`;
-    logErrEmailHeather(subject, err, user, assignment);
-  });
+  const logErrEmailHeather = createLogErrEmailHeatherFunc(`platform user:` +
+        `${JSON.stringify(user)} was not able to be given credit for ${assignment}`);
 
-  // request courses and find correct courseId;
-  promiseCourseID = promiseUserID.then((userID) => {
-    return canvas.scrapeCanvasEnrollment(userID);
-    })
-    .then((courses) => {
-    courses = courses.filter((course) => {
-      return course.enrollment_state === 'active';
-    });
-    if (courses.length === 0) throw 'No active courses for that user were found in Canvas.';
-    return courses[0].course_id;
-  }).catch(err => 
-    CONSOLE_WITH_TIME(`Error finding active course for ${user.email}: ${err}`)
-  );
-
-  // request assignments for course and find correct assignment
-  promiseAssignmentID = promiseCourseID.then((courseID) => {
-    return canvas.scrapeCanvasAssignments(courseID, assignment);
-  })
-  .then(assignments => {
-    if (assignments.length === 0) throw `Canvas returned 0 assignments`;
-    return assignments[0].id;
-  }).catch(err => {
-    const subject = `Error finding ${assignment} in course found for ${user.email}`;
-    logErrEmailHeather(subject, err, user, assignment);
-  });
-
-
-  Promise.all([promiseUserID, promiseCourseID, promiseAssignmentID])
+  canvas.retrieveUserCourseAssignmentIds(user.email, assignment, logErrEmailHeather)
   .then(responses => {
     // responses is [userID, courseID, assignmentID] so we spread it
     return canvas.updateUserGrade(...responses, 'complete');
@@ -68,26 +32,53 @@ router.put('/firstShift', function (req, res) {
   stathat.increment('Canvas - Attend First Shift', 1);
 });
 
-function logErrEmailHeather (subject, err, user, assignment) {
-  CONSOLE_WITH_TIME(`${subject}: ${err}`);
+router.post('/typeformAssignment/:assignment', function (req, res) {
+  const formResponse = req.body.form_response;
+  const emailWithSubmission = helpers.extractEmailAndFormatSubmission(formResponse);
+  const assignment = req.params.assignment;
+  const logErrEmailHeather = createLogErrEmailHeatherFunc(`typeform submission for email:` +
+        `${emailWithSubmission.email} was not able to be given credit for ${assignment}`);
 
-  const message = {
-    subject: subject,
-    text: `Hi Heather, Due to the specified error in the subject platform user:` +
-      `${JSON.stringify(user)} was not able to be given credit for ${assignment}`,
-    from_email: 'support@crisistextline.org',
-    from_name: 'Crisis Text Line',
-    to: [{
-        email: 'heather@crisistextline.org',
-        name: 'Heather',
-        type: 'to'
-    }]
-  };
-
-  mandrillClient.messages.send({message: message, key: 'canvas_user_not_found'}, function (res) {
-      CONSOLE_WITH_TIME(res);
+  canvas.retrieveUserCourseAssignmentIds(emailWithSubmission.email, assignment, logErrEmailHeather)
+  .then(responses => {
+    // responses is [userID, courseID, assignmentID] so we spread it
+    const promises = [canvas.submitAssignment(...responses, emailWithSubmission.submissionHTML)];
+    if (formResponse.calculated && formResponse.calculated.score) {
+      promises.push(canvas.updateUserGrade(...responses, formResponse.calculated.score));
+    }
+    return Promise.all(promises);
+  }).then(() => res.send({message: `Successfully submitted ${assignment} with ${JSON.stringify(emailWithSubmission)}`}))
+  .catch((err) => {
+    const message = `Submitting ${assignment} for ${emailWithSubmission.email} in Canvas failed: ${err}`;
+    CONSOLE_WITH_TIME(message);
+    res.status(500).send({message});
   });
+});
 
+
+function createLogErrEmailHeatherFunc (messageText) {
+
+  return (subject, err) => {
+    CONSOLE_WITH_TIME(`${subject}: ${err}`);
+
+    const message = {
+      subject: subject,
+      text: `Hi Heather, Due to the error specified in the subject ` + messageText,
+      from_email: 'support@crisistextline.org',
+      from_name: 'Crisis Text Line',
+      to: [{
+          email: 'heather@crisistextline.org',
+          name: 'Heather',
+          type: 'to'
+      }]
+    };
+
+    mandrillClient.messages.send({message: message, key: 'canvas_user_not_found'}, function (res) {
+        CONSOLE_WITH_TIME(res);
+    });
+  };
+  
 }
+
 
 module.exports = {router};


### PR DESCRIPTION
#### What's this PR do?
Creates a route for assignments submitted by typeform.
Add Canvas functionality for submitting assignments.
#### Where should the reviewer start?
#### How should this be manually tested?
1: Create a test Canvas account with a Canvas assignment that accepts text based submission
2: node www/app.js 
3: post to localhost/canvas/typeformAssignment/:assignment
with a typeform like body (swap in the email associated with the canvas account):  `{
  "event_id": "UwVP9f9sGU",
  "event_type": "form_response",
  "form_response": {
    "form_id": "L5aBhG",
    "token": "875527530cbc8ec306774088db80887f",
    "submitted_at": "2016-08-12T14:49:14Z",
    "calculated": {
      "score": 15
    },
    "definition": {
      "id": "L5aBhG",
      "title": "",
      "fields": [
        {
          "id": "3",
          "title": "Question text: 3",
          "type": "textfield"
        },
        {
          "id": "2",
          "title": "Question Bool: 2>",
          "type": "yes-no"
        },
        {
          "id": "1",
          "title": "Please enter your email below",
          "type": "email"
        }
      ]
    },
    "answers": [
      {
        "type": "text",
        "text": "asdfg",
        "field": {
          "id": "3",
          "type": "short_text"
        }
      },
      {
        "type": "boolean",
        "boolean": true,
        "field": {
          "id": "2",
          "type": "yes_no"
        }
      },
      {
        "type": "email",
        "email": "abc@abc.com",
        "field": {
          "id": "1",
          "type": "email"
        }
      }
    ]
  }
}`

#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-223
#### Questions:

