### PR TITLE
Changed all queries including 'include_objects=false' to put that in …

### DIFF
--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -15,9 +15,10 @@ handleTimeOffRequests();
 
 function handleTimeOffRequests() {
   var timeOffSearchParams = createTimeOffSearchParams();
+  timeOffSearchParams.include_objects = false;
 
   //Get all time off requests within timeOffSearchParams
-  WhenIWork.get('requests?include_objects=false', timeOffSearchParams, function(response){
+  WhenIWork.get('requests', timeOffSearchParams, function(response){
     filterRequestsAndHandleShifts(response.requests);
   });
 }
@@ -49,8 +50,9 @@ function filterRequestsAndHandleShifts (allRequests) {
 
 function retrieveOverlappingShifts (request) {
   var shiftSearchParams = createShiftSearchParams(request);
+  shiftSearchParams.include_objects = false;
 
-  WhenIWork.get('shifts?include_objects=false', shiftSearchParams, function(response) {
+  WhenIWork.get('shifts', shiftSearchParams, function(response) {
     var batchPayload = createBatchPayload (response, request.id);
     //Send the time off request approval and all shift deletions/open shift creations to batch
     WhenIWork.post('batch', batchPayload, function(response) {

--- a/tasks/color.js
+++ b/tasks/color.js
@@ -8,10 +8,11 @@ module.exports.go = function () {
     start: '-1 day',
     end:   '+2 weeks',
     include_allopen: true,
-    locationId: [CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts]
+    locationId: [CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts],
+    include_objects: false
   };
 
-  api.get('shifts?include_objects=false', filter, function (results) {
+  api.get('shifts', filter, function (results) {
     var openShifts = results.shifts.filter(function (e) {
 	    return e.is_open;
     });

--- a/tasks/deleteOpenUnpubShifts.js
+++ b/tasks/deleteOpenUnpubShifts.js
@@ -9,10 +9,11 @@ module.exports.go = function() {
 			"location_id": CONFIG.locationID.regular_shifts,
 			"start": '+' + i + ' days',
 			"end": '+' + (i+7) + ' days',
-			"unpublished": true
+			"unpublished": true,
+			"include_objects": false
 		};
 		var batchRequest = [];
-		api.get('shifts?include_objects=false', postData, function(response) {
+		api.get('shifts', postData, function(response) {
 			response.shifts.forEach(function(shift) {
 				if (shift.is_open && !shift.published) {
 					var shiftDeleteRequest = {

--- a/tasks/makeEmails.js
+++ b/tasks/makeEmails.js
@@ -22,7 +22,10 @@ for (var i in emails) {
 // node console makeEmails go
 module.exports.go = function () {
   var batchRequestArray = [];
-  api.get('users?include_objects=false', function (data) {
+  var params = {
+    include_objects: false
+  };
+  api.get('users', params, function (data) {
     data.users.forEach(function (obj, i, arr) {
       updateNotes(obj, batchRequestArray);
     });

--- a/tasks/removeChurned.js
+++ b/tasks/removeChurned.js
@@ -17,7 +17,10 @@ function getUsersToClean() {
   return new Promise(function (resolve, reject) {
     var users, email;
     var uidsToClean = [];
-    api.get('users?include_objects=false', function (res) {
+    var params = {
+      include_objects: false
+    };
+    api.get('users', params, function (res) {
       if (!res) reject('Call to get WiW users failed');
       users = res.users;
       users.forEach(function (each) {

--- a/tasks/schedule.js
+++ b/tasks/schedule.js
@@ -9,12 +9,13 @@ const out_format = 'ddd h:mm A';
 
 module.exports.dumpSchedules = function () {
   // We want to see shifts 8 days out from now.
-  var params = {
+  let params = {
     location_id: CONFIG.locationID.regular_shifts,
-    end: '+8 days'
+    end: '+8 days',
+    include_objects: false
   };
 
-  api.get('shifts?include_objects=false', params, function (data) {
+  api.get('shifts', params, function (data) {
     var user_shifts = {};
     var shift;
 
@@ -33,7 +34,10 @@ module.exports.dumpSchedules = function () {
     }
 
     // Now we need to get the email addresses
-    api.get('users?include_objects=false', function (data) {
+    let params = {
+      include_objects: false
+    };
+    api.get('users', params, function (data) {
       var user;
       for (var i in data.users) {
         user = data.users[i];
@@ -76,10 +80,11 @@ module.exports.clearProd = function() {
       end: end_time,
       location_id: CONFIG.locationID.test,
       unpublished: true,
-      include_allopen: true
+      include_allopen: true,
+      include_objects: false
     };
 
-    api.get('shifts?include_objects=false', query, function (data) {
+    api.get('shifts', query, function (data) {
       var shifts_to_delete = [];
       for (var i in data.shifts) {
         shifts_to_delete.push(data.shifts[i].id);

--- a/tasks/usersWithTimezones.js
+++ b/tasks/usersWithTimezones.js
@@ -18,7 +18,10 @@ module.exports.usersTimezones = function () {
 
   function getTimezones () {
     return new Promise(function(resolve, reject){
-      api.get('timezones?include_objects=false', function(response) {
+      let params = {
+        include_objects: false
+      };
+      api.get('timezones', params, function(response) {
         if (!response) reject(response);
         else resolve(response);
       });
@@ -27,7 +30,10 @@ module.exports.usersTimezones = function () {
 
   function getUsersPromise () {
     return new Promise(function(resolve, reject){
-      api.get('users?include_objects=false', {}, function(response) {
+      let params = {
+        include_objects: false
+      };
+      api.get('users', params, function(response) {
         if (!response.users) reject(response);
         else resolve(response);
       });

--- a/test/helpers/base.js
+++ b/test/helpers/base.js
@@ -13,17 +13,11 @@ WhenIWork.prototype.get =  function(term, params, cbFunction){
   //is the second argument. May need to change this
   //in the future depending on what gets passed to 'get'.
   cbFunction = [].slice.call(arguments).pop();  
-  if (term === 'users?include_objects=false') {
-    cbFunction(sampleData.usersResponse);
-  }
-  else if (term === 'users') {
+  if (term === 'users') {
     cbFunction(sampleData.usersResponse);
   }
   else if (term === 'users/7889841') {
     params({user: sampleData.usersResponse.users[2]});
-  }
-  else if (term === 'shifts?include_objects=false') {
-    cbFunction(sampleData.shiftsResponse);
   }
   else if (term === 'shifts') {
     cbFunction(sampleData.shiftsResponse);

--- a/www/scheduling/shifts/controllers/retrieveAndRenderShiftsToDelete.js
+++ b/www/scheduling/shifts/controllers/retrieveAndRenderShiftsToDelete.js
@@ -17,8 +17,11 @@ function retrieveAndRenderShiftsToDelete(req, res, whenIWorkAPI) {
   }
 
   var altEmail = helpers.generateAltEmail(email);
+  var params = {
+    include_objects: false
+  };
 
-  whenIWorkAPI.get('users?include_objects=false', function (dataResponse) {
+  whenIWorkAPI.get('users', params, function (dataResponse) {
     var users = dataResponse.users
       , user
       , templateData
@@ -35,10 +38,10 @@ function retrieveAndRenderShiftsToDelete(req, res, whenIWorkAPI) {
           user_id: userID,
           start: '-1 day',
           end: '+180 days',
-          location_id: [CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts]
+          location_id: [CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts],
+          include_objects: false
         };
 
-        // Need to not add `include_objects=false`, otherwise query returns all shifts. No idea why.
         whenIWorkAPI.get('shifts', query, function(response) {
           var url = scheduleShiftsURL + 'email=' + encodeURIComponent(email) + '&token=' + req.query.token;
           if (!response.shifts || !response.shifts.length) {

--- a/www/scheduling/shifts/controllers/retrieveShiftsAndOwnersWithinTimeInterval.js
+++ b/www/scheduling/shifts/controllers/retrieveShiftsAndOwnersWithinTimeInterval.js
@@ -34,10 +34,11 @@ function retrieveShiftsAndOwnersWithinTimeInterval(req, res, whenIWorkAPI) {
   var query = {
     start: moment.unix(startTime).format(wiwDateFormat),
     end: moment.unix(endTime).format(wiwDateFormat),
-    location_id: [ CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts ]
+    location_id: [ CONFIG.locationID.regular_shifts, CONFIG.locationID.makeup_and_extra_shifts ],
+    include_objects: false
   };
 
-  whenIWorkAPI.get('shifts?include_objects=false', query, function(response) {
+  whenIWorkAPI.get('shifts', query, function(response) {
     var shifts = response.shifts
       , shift
       , userShiftData = {}


### PR DESCRIPTION
#### What's this PR do?
Changes all calls to the WiW API that used to include "?include_objects=false" as part of the query string. Those were failing because the WiW unofficial API was adding a question mark of its own. Instead, all calls now include "include_objects: false" in a parameters object.
#### Where should the reviewer start?
Search globally for "include_objects" to see all the places where it is used.
#### How should this be manually tested?
Npm test and/or node any file that uses an "include_objects: false" object to see that extra objects are not returned. I tested each altered file with this process:
1. Add global.KEYS and global.CONFIG definitions to the file I want to test.
2. Add a global.KEYS definition to api_wiw/WiWCCApi.js.
3. Add a console.log to the callback function that runs on the response from WiW to see what is returned. Comment out anything in the callback function that I don't want to run (I just commented out everything other than the console.log to be safe).
4. Ensure that the function that I want to run in order to make the WiW API call is going to run. To do this, sometimes I needed to call the function in the file I wanted to test.
5. Confirm that extra objects (e.g. locations for a 'shifts' get call) are not returned in the terminal.

#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-297
](https://admin.crisistextline.org/jira/browse/INT-297)#### Questions:

…a params object instead of a query string, as the query string was turning out malformed.