### PR TITLE
Changed all urls including '/2/' at the beginning to delete the redun…

### DIFF
--- a/jobs/scheduling/MergeOpenShifts.js
+++ b/jobs/scheduling/MergeOpenShifts.js
@@ -91,7 +91,7 @@ function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, 
 
         var shiftUpdateRequest = {
           'method': 'PUT',
-          'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
+          'url': '/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
           'params': update
         };
 
@@ -100,7 +100,7 @@ function makeBatchPayloadRequestsToMergeOpenShifts(arrayOfShiftsForSameTimeInt, 
       } else {
         var shiftDeleteRequest = {
           'method': 'delete',
-          'url': '/2/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
+          'url': '/shifts/' + arrayOfShiftsForSameTimeInt[j].id,
           'params': {}
         };
         batchPayload.push(shiftDeleteRequest);

--- a/jobs/scheduling/NotifyMoreShifts.js
+++ b/jobs/scheduling/NotifyMoreShifts.js
@@ -112,7 +112,7 @@ function shiftNotification(users, usersToNotify) {
         user_data[CONFIG.WiWUserNotes.shiftNotification] = true;
         updateUserNotes.push({
           method: 'PUT',
-          url: '/2/users/' + user.id,
+          url: '/users/' + user.id,
           params: {notes: JSON.stringify(user_data)}
         });
 

--- a/jobs/scheduling/RecurOpenShifts.js
+++ b/jobs/scheduling/RecurOpenShifts.js
@@ -169,7 +169,7 @@ function createOpenShift (correctNumberOfShiftsToSet, targetTime, weeksFromNowTo
 
   const newOpenShiftRequest = {
     method: `post`,
-    url: `/2/shifts`,
+    url: `/shifts`,
     params: newOpenShiftParams
   };
 
@@ -180,7 +180,7 @@ function removeOpenShifts(shifts) {
   return shifts.map(function(shiftID) {
     const shiftDeleteRequest = {
       method: `delete`,
-      url: `/2/shifts/` + shiftID,
+      url: `/shifts/` + shiftID,
       params: {}
     };
     return shiftDeleteRequest;

--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -84,7 +84,7 @@ function recurNewlyCreatedShifts() {
 
       shift.chain = {'week':'1','until':endDate};
       shift.acknowledged = 1;
-      var urlIDRoute = '/2/shifts/' + shift.id;
+      var urlIDRoute = '/shifts/' + shift.id;
       shift = {'method': 'put', 'url': urlIDRoute, 'params': shift};
 
       batchPostRequestBody.push(shift);
@@ -101,7 +101,7 @@ function recurNewlyCreatedShifts() {
       for (var i = 0; i < CONFIG.time_interval.years_to_recur_shift - 1; i++) {
         var newShift = {
           'method': 'post',
-          'url': '/2/shifts',
+          'url': '/shifts',
           'params': {
             'start_time': moment(workingShift.start_time, wiw_date_format).add(CONFIG.time_interval.max_shifts_in_chain, 'weeks').format(wiw_date_format),
             'end_time': moment(workingShift.end_time, wiw_date_format).add(CONFIG.time_interval.max_shifts_in_chain, 'weeks').format(wiw_date_format),
@@ -260,7 +260,7 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
         if (instances === 1) {
           var shiftDeleteRequest = {
             'method': 'delete',
-            'url': '/2/shifts/' + shift.id,
+            'url': '/shifts/' + shift.id,
             'params': {}
           };
           batchPayload.push(shiftDeleteRequest);
@@ -269,7 +269,7 @@ function decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift) {
           instances = instances - 1;
           var shiftUpdateRequest = {
             'method': 'PUT',
-            'url': '/2/shifts/' + shift.id,
+            'url': '/shifts/' + shift.id,
             'params': {instances: instances}
           };
           batchPayload.push(shiftUpdateRequest);

--- a/jobs/scheduling/TimeOffRequests.js
+++ b/jobs/scheduling/TimeOffRequests.js
@@ -86,7 +86,7 @@ function createBatchPayload (response, requestId) {
     response.shifts.forEach(function(shift) {
       var shiftDeleteRequest = {
         'method': 'delete',
-        'url': '/2/shifts/' + shift.id,
+        'url': '/shifts/' + shift.id,
         'params': {},
       };
 
@@ -105,7 +105,7 @@ function createBatchPayload (response, requestId) {
 
       var newOpenShiftRequest = {
         'method': 'post',
-        'url': '/2/shifts',
+        'url': '/shifts',
         'params': params
       };
       batchPayload.push(newOpenShiftRequest);
@@ -119,7 +119,7 @@ function createTimeOffApproval (requestId) {
     // Status code `2` represents approved requests.
   var timeOffApprovalRequest = {
     'method': 'put',
-    'url': '/2/requests/' + requestId,
+    'url': '/requests/' + requestId,
     'params': {
       'status': 2
     }

--- a/tasks/color.js
+++ b/tasks/color.js
@@ -25,7 +25,7 @@ module.exports.go = function () {
       update = colorize({}, e.start_time, (e.location_id === CONFIG.locationID.makeup_and_extra_shifts));
       var shiftDeleteRequest = {
         "method": "PUT",
-        "url": "/2/shifts/" + e.id,
+        "url": "/shifts/" + e.id,
         "params": update,
       };
       batchRequest.push(shiftDeleteRequest);

--- a/tasks/deleteOpenUnpubShifts.js
+++ b/tasks/deleteOpenUnpubShifts.js
@@ -18,7 +18,7 @@ module.exports.go = function() {
 				if (shift.is_open && !shift.published) {
 					var shiftDeleteRequest = {
 						"method": "delete",
-						"url": "/2/shifts/" + shift.id,
+						"url": "/shifts/" + shift.id,
 						"params": {},
 					};
 					batchRequest.push(shiftDeleteRequest);

--- a/tasks/makeEmails.js
+++ b/tasks/makeEmails.js
@@ -79,7 +79,7 @@ function updateNotes(user, batchRequestArray) {
     CONSOLE_WITH_TIME('updating user with: ', note);
     updateRequest = {
       method: 'PUT',
-      url: '/2/users/' + user.id,
+      url: '/users/' + user.id,
       params: {
         notes: JSON.stringify(note)
       }

--- a/test/notifyMoreShifts.js
+++ b/test/notifyMoreShifts.js
@@ -19,10 +19,10 @@ describe('Notify More Shifts', function() {
     it('creates correct post object for users not yet notified', function (done) {
     
       var expectedBatchPosts = [ { method: 'PUT',
-        url: '/2/users/5674723',
+        url: '/users/5674723',
         params: { notes: '{"firstShiftNotification":true}' } },
       { method: 'PUT',
-        url: '/2/users/5674724',
+        url: '/users/5674724',
         params: { notes: '{"two_shift_notification":true,"original_owner":5674723,"parent_shift":277119256,"firstShiftNotification":true}' } } ];
       assert.deepEqual(batchPosts, expectedBatchPosts);
       done();

--- a/test/recurOpenShifts.js
+++ b/test/recurOpenShifts.js
@@ -42,7 +42,7 @@ describe('recurOpenShifts', function() {
     
     it('should increment future open shifts up or down', function () {
       assert.equal(result[0].params.instances, 6);
-      assert.deepEqual(result[4], { method: 'delete', url: '/2/shifts/284948029', params: {} });
+      assert.deepEqual(result[4], { method: 'delete', url: '/shifts/284948029', params: {} });
     });
 
   });

--- a/test/recurShifts.js
+++ b/test/recurShifts.js
@@ -48,7 +48,7 @@ describe('recurShifts', function() {
 
     it('decrements previous and next week\'s open shifts by one', function (done) {
       var decrementResult = recurNewlyCreatedShifts.decrementPrevWeeksAndNextWeeksOpenShiftsByOne(testShift);
-      assert.equal(decrementResult[0].url, '/2/shifts/284948029');
+      assert.equal(decrementResult[0].url, '/shifts/284948029');
       done();
     });
 });

--- a/test/timeOffRequests.js
+++ b/test/timeOffRequests.js
@@ -81,7 +81,7 @@ describe('Time Off Requests', function() {
     var BatchPayload = timeOffRequests.createBatchPayload (shiftsResponse, requestId);
     var timeOffApprovalRequest = {
       "method": "put",
-      "url": "/2/requests/123456",
+      "url": "/requests/123456",
       "params": {
         "status": 2
       }
@@ -107,14 +107,14 @@ describe('Time Off Requests', function() {
     it('should create a shiftDeleteRequest for each shift that will be missed', function () {
       deleteRequests.forEach(function(req, idx) {
         assert.equal(req.method, "delete");
-        assert.equal(req.url, "/2/shifts/" + shiftsResponse.shifts[idx].id);
+        assert.equal(req.url, "/shifts/" + shiftsResponse.shifts[idx].id);
       });
     });
 
     it('should create new open shifts for all shifts deleted', function () {
       openShiftRequests.forEach(function(req, idx) {
         assert.equal(req.method, "post");
-        assert.equal(req.url, "/2/shifts");
+        assert.equal(req.url, "/shifts");
         assert.equal(req.params.start_time, shiftsResponse.shifts[idx].start_time);
         assert.equal(req.params.end_time, shiftsResponse.shifts[idx].end_time);
         assert.equal(req.params.notes, "SHIFT COVERAGE");

--- a/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
+++ b/www/scheduling/shifts/controllers/deleteShiftsAndRedirect.js
@@ -65,7 +65,7 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
               updatedShiftParams = returnColorizedShift(updatedShiftParams, shift.start_time);
               var reassignShiftToOpenAndRemoveNotesRequest = {
                 "method": 'PUT',
-                "url": "/2/shifts/" + shift.id,
+                "url": "/shifts/" + shift.id,
                 "params": updatedShiftParams
               };
               batchPayload.push(reassignShiftToOpenAndRemoveNotesRequest);
@@ -74,7 +74,7 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
             else {
               var shiftDeleteRequest = {
                   "method": "delete",
-                  "url": "/2/shifts/" + shift.id,
+                  "url": "/shifts/" + shift.id,
                   "params": {},
               };
               batchPayload.push(shiftDeleteRequest);
@@ -94,7 +94,7 @@ function deleteShiftsAndRedirect(req, res, whenIWorkAPI) {
           param = returnColorizedShift(params, shift.start_time, true);
           var openShiftRequest = {
             method : 'PUT',
-            url : '/2/shifts/' + shift.id,
+            url : '/shifts/' + shift.id,
             params : params
           };
           batchPayload.push(openShiftRequest);

--- a/www/scheduling/shifts/controllers/retrieveShiftsAndOwnersWithinTimeInterval.js
+++ b/www/scheduling/shifts/controllers/retrieveShiftsAndOwnersWithinTimeInterval.js
@@ -57,7 +57,7 @@ function retrieveShiftsAndOwnersWithinTimeInterval(req, res, whenIWorkAPI) {
           userShiftData[shift.user_id] = [shift];
           getUserEmailRequest = {
             "method": "GET",
-            "url": "/2/users/" + shift.user_id
+            "url": "/users/" + shift.user_id
           };
           batchPayload.push(getUserEmailRequest);
         }


### PR DESCRIPTION
#### What's this PR do?
There are lots of places in our code where we include '/2/shifts/', for example, as a url in our parameters. However, these urls eventually get sent to the When I Work unofficial API, which automatically begins every url thusly: 
```this.endpoint = 'https://api.wheniwork.com/2';```
so as far as I can tell the '2' is redundant, and may have even been causing some problems. I deleted the '/2' everywhere I found it.
#### Where should the reviewer start?
Do a global find for '/2' or "/2" or `/2` to make sure I didn't miss anything.
#### How should this be manually tested?
Run any of the affected files in Node and console.log the results to ensure that their WiW calls are working. Run npm test as well.
#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-356
](https://admin.crisistextline.org/jira/browse/INT-356)#### Questions:

…dant 2.