### PR TITLE
Notify CCs and delete open shifts after WiW confirms recurring shifts

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -33,6 +33,7 @@ function recurNewlyCreatedShifts() {
                   };
 
   WhenIWork.get('shifts', postData, function(response) {
+    const usersWithNewShifts = response.users;
     var allShifts = response.shifts;
     if (typeof allShifts !== 'object') {
       CONSOLE_WITH_TIME('NO SHIFTS RETURNED.');
@@ -50,7 +51,6 @@ function recurNewlyCreatedShifts() {
     var newShifts = allShifts.filter(function(shift) {
       return !shift.notes;
     });
-    if (newShifts.length) notifyUserBookedShift.notifyUserBookedShift(newShifts, response.users);
 
     stathat.increment('Scheduling - Shifts Recurred', newShifts.length);
 
@@ -61,12 +61,6 @@ function recurNewlyCreatedShifts() {
       also need to be deleted.
     **/
     newShifts.forEach(function(shift) {
-      /**
-        Reduces open shift count by 1 for previous week's and next week's open shifts
-        at same time slot. Note that this is happening asynchronously--nothing else in this
-        job relies on this completing at a specific time.
-      **/
-      decrementPrevWeeksAndNextWeeksOpenShiftsByOne(shift);
 
       shift.notes = '{"original_owner":' + shift.user_id + ', "parent_shift":' + shift.id + '}';
       var endDate = moment(shift.start_time, wiw_date_format).add(CONFIG.time_interval.max_shifts_in_chain - 1, 'weeks').format('L');
@@ -118,14 +112,32 @@ function recurNewlyCreatedShifts() {
     });
 
     WhenIWork.post('batch', batchPostRequestBody, function(response) {
+      const successfullyRecurredShifts = {};
+      if (response) {
+        response.forEach((obj, idx) => {
+          if (obj.error) CONSOLE_WITH_TIME(`Error: ${obj.error} in RecurShift Batch Response ${JSON.stringify(response[idx-1])}`);
+          if (obj.shift 
+              && /parent_shift/.test(obj.shift.notes)
+              && obj.shift.id === JSON.parse(obj.shift.notes).parent_shift) {
+            successfullyRecurredShifts[obj.shift.id] = 'recurred';
+          }
+        })
+
+        const updatedNewShifts = newShifts.filter(shift => successfullyRecurredShifts[shift.id]);
+
+        notifyUserBookedShift.notifyUserBookedShift(updatedNewShifts, usersWithNewShifts);
+        /**
+          Reduces open shift count by 1 for previous week's and next week's open shifts
+          at same time slot. Note that this is happening asynchronously--nothing else in this
+          job relies on this completing at a specific time.
+        **/
+        updatedNewShifts.forEach(decrementPrevWeeksAndNextWeeksOpenShiftsByOne);
+      };
+
       /**
         After batch of shifts is created, we want to publish all shifts. (Note that passing in the `published` param
         in the requests that are batched doesn't actually publish them; we need to make a separate request to another route.)
       **/
-
-      //The response at this point doesn't include error status codes so we're looking for a message that indicates an error
-      if (response && response.message && /error/.test(response.message)) CONSOLE_WITH_TIME("Error in RecurShift Batch Response: ", response);
-
       var startDateToRetrieveUnpublishedShifts = moment().add(-12, 'hours').format('YYYY-MM-DD HH:mm:ss');
       var endDateToRetrieveUnpublishedShifts = moment().add(12, 'hours').format('YYYY-MM-DD HH:mm:ss');
       for (var i = 0; i < CONFIG.time_interval.weeks_to_publish_recurred_shifts * 7; i++) {

--- a/jobs/scheduling/helpers/notifyUserBookedShift.js
+++ b/jobs/scheduling/helpers/notifyUserBookedShift.js
@@ -5,9 +5,10 @@ const moment = require('moment');
 const retrieveAndSortSupervisorsByShift = require('./sortUsersByShift');
 const composeEmail = require(CONFIG.root_dir + '/email_templates/composeNotifyBookedShift');
 const mandrill = require('mandrill-api/mandrill');
-const mandrill_client = new mandrill.Mandrill(KEYS.mandrill.api_key);
+const mandrillClient = new mandrill.Mandrill(KEYS.mandrill.api_key);
 
 function notifyUserBookedShift (shifts, users) {
+  if (!shifts.length) return;
   var userIdToInfo = filterUsersToObject(users);
   retrieveAndSortSupervisorsByShift(wIWSupervisorsAPI, CONFIG.locationID.supervisor_on_platform, CONFIG.wiwAccountID.supervisors)
   .then(function(shiftsToSup){
@@ -60,7 +61,7 @@ function mandrillEachUser (shifts, userIdToInfo, shiftsToSup){
       }
     };
 
-    mandrill_client.messages.send({message: message}, CONSOLE_WITH_TIME);
+    mandrillClient.messages.send({message: message}, CONSOLE_WITH_TIME);
   });
 
   // results are returned for testing.


### PR DESCRIPTION
#### What's this PR do?
We were notifying CC's that their shifts have been scheduled before they were successfully recurred. So if recurring failed they would get notified every time we tried to recur their shifts. This has been modified so we only notify them (and 
#### Where should the reviewer start?
#### How should this be manually tested?
1. Add this to the top of the file:
global.KEYS = require('../../keys.js');
global.CONFIG = require('../../config.js');
CONFIG.locationID.regular_shifts = CONFIG.locationID.test;
console.log('testing');

2. Create a test shift in wheniwork

3. node RecurShifts.js and you should get an email. 

#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-362
#### Other:
There's separate small formatting bug that is logging errors, but I don't believe is causing other issues. I added it to the backlog.

