### PR TITLE
Fixed bug causing future shift chains to start at odd times.

### DIFF
--- a/jobs/scheduling/RecurShifts.js
+++ b/jobs/scheduling/RecurShifts.js
@@ -85,7 +85,7 @@ function recurNewlyCreatedShifts() {
 
       var workingShift = shift.params;
       /**
-          Because the WhyIWork API doesn't allow us to create a recurring chain
+          Because the WhenIWork API doesn't allow us to create a recurring chain
           shift with a duration longer than a year, we need to create X number of chains
           with X being the number of years we want the shift to recur.
           In order to associate all the shifts in all the chains together (i.e., if we wanted to delete
@@ -101,7 +101,7 @@ function recurNewlyCreatedShifts() {
             'end_time': moment(workingShift.end_time, wiw_date_format).add(CONFIG.time_interval.max_shifts_in_chain, 'weeks').format(wiw_date_format),
             'notes': workingShift.notes,
             'acknowledged': workingShift.acknowledged,
-            'chain': {'week': '1', 'until': moment(workingShift.chain.until, wiw_date_format).add(CONFIG.time_interval.max_shifts_in_chain, 'weeks').format('L')},
+            'chain': {'week': '1', 'until': moment(new Date(workingShift.chain.until)).add(CONFIG.time_interval.max_shifts_in_chain, 'weeks').format('L')},
             'location_id': workingShift.location_id,
             'user_id': workingShift.user_id
           }


### PR DESCRIPTION
#### What's this PR do?
Fixes RecurShifts to accurately create future shift chains (currently for 5 years in the future). Previously future chains had started at a weird date.
#### Where should the reviewer start?
RecurShifts.js.
#### How should this be manually tested?
Since recurNewlyCreatedShifts is such a big, complex function, I find it easiest and safest to do the following:

1. Add GLOBAL.KEYS and GLOBAL.CONFIG to the top of the recurShifts.js file:
a) GLOBAL.KEYS = require('../../keys.js');
b) GLOBAL.CONFIG = require('../../config.js');
2. Add GLOBAL.KEYS to the top of the WiWCCApi.js file: GLOBAL.KEYS = require('../keys.js');
3. Comment out the CronJob on line 11 of the recurShifts.js file.
4. Comment out lines 26-55 of recurShifts.js.
5. Comment out all lines from 114-232 inclusive (the end of the recurNewlyCreatedShifts function).
6. Add the following sample shift array right before line 63: 

```
var newShifts = [{
      "id": 281636131,
      "account_id": 549781,
      "user_id": 5439292,
      "location_id": 1003765,
      "position_id": 0,
      "site_id": 0,
      "start_time": "Mon, 12 Sep 2016 14:00:00 -0400",
      "end_time": "Mon, 12 Sep 2016 16:00:00 -0400",
      "break_time": 0,
      "color": "cccccc",
      "notes": "",
      "alerted": true,
      "linked_users": null,
      "shiftchain_key": "4ngvim",
      "published": true,
      "published_date": "Tue, 16 Aug 2016 02:00:25 -0400",
      "notified_at": "Fri, 09 Sep 2016 16:57:26 -0400",
      "instances": 1,
      "created_at": "Mon, 18 Jan 2016 08:52:20 -0500",
      "updated_at": "Mon, 12 Sep 2016 12:05:30 -0400",
      "acknowledged": 1,
      "acknowledged_at": null,
      "creator_id": 5005069,
      "is_open": false,
      "actionable": false,
      "block_id": 0
    }];
```
And right before what should now be line 138 ("batchPostRequestBody.push(newShift);"), insert this:

```
console.log("New chain goes until: " + newShift.params.chain.until);
```

Finally, node recurShifts.js and confirm that the future chains have the right until dates (every year for 5 years): 
09/03/2018
09/02/2019
08/31/2020
08/30/2021

#### Any background context you want to provide?
#### What are the relevant tickets?
[INT-52](https://admin.crisistextline.org/jira/browse/INT-52)
#### Questions:

