### PR TITLE
changed the webinar attendance cronjob to run at 11 15 pm instead of …

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,7 +94,7 @@ CONFIG.WiWUserNotes = {
 
 CONFIG.time_interval = {
   // runs every day at 5am
-  gtw_attendance_sync_with_canvas:'0 0 5 * * *',
+  gtw_attendance_sync_with_canvas:'0 15 23 * * *',
   // runs every 1 min.
   recur_and_publish_shifts_cron_job_string: '0 */1 * * * *',
   // runs every day


### PR DESCRIPTION
#### What's this PR do?
changes when the attendancesync script runs from 5am to 11:15pm. why? most webinars run from 9pm to 11pm and trainees were freaking out and emailing trainers about not seeing credit for attending the webinar on canvas right away. 

#### Where should the reviewer start?
config.js

#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Questions:

…5 am