### PR TITLE
Temporary typeform workaround

### DIFF
--- a/www/canvas/helpers.js
+++ b/www/canvas/helpers.js
@@ -22,19 +22,23 @@ function extractEmailAndFormatSubmission (formResponse) {
     }
   });
 
-  let qWithBolding = '';
+  // let qWithBolding = '';
 
-  const pairedQtoA = formResponse.definition.fields
-                      .sort((a,b) => a.title.localeCompare(b.title))
-                      .map(formatHTML);
+  // TODO A typeform error is causing formResponse.definition = null;
+  // const pairedQtoA = formResponse.definition.fields
+  //                     .sort((a,b) => a.title.localeCompare(b.title))
+  //                     .map(formatHTML);
 
-  function formatHTML (question, idx) {
-    qWithBolding = question.title.replace('Texter: ', '<b>Texter: </b>');
-    return `<h1>${idx}: ${qWithBolding}</h1>` +
-    `<h2><b>Crisis Counselor: </b>${answers[question.id]}</h2>`;
-  }
+  // function formatHTML (question, idx) {
+  //   qWithBolding = question.title.replace('Texter: ', '<b>Texter: </b>');
+  //   return `<h1>${idx}: ${qWithBolding}</h1>` +
+  //   `<h2><b>Crisis Counselor: </b>${answers[question.id]}</h2>`;
+  // }
   
-  emailWithSubmission.submissionHTML = `<p> ${pairedQtoA.join('</p><br><p>')} </p>`;
+  // emailWithSubmission.submissionHTML = `<p> ${pairedQtoA.join('</p><br><p>')} </p>`;
+
+  // TODO This is a temporary fix for submissions until typeform solves their Webhook issue
+  emailWithSubmission.submissionHTML = `<p>${formResponse.answers.map(elem => JSON.stringify(elem)).join('</p><br><p>')}</p>`;
 
   return emailWithSubmission;
 }


### PR DESCRIPTION
#### What's this PR do?
Typeform error in Webhooks is causing formResponse.definition = null 
This section should contain the questions from the form. We have a ticket in process with them.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://admin.crisistextline.org/jira/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=INT-458
#### Questions:

